### PR TITLE
feat: add dataguard SSH domain to allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2026.04.10.4
+
+- feat: add `dataguard` SSH domain with `dgmgrl` to default allowlist (#7)
+
 ## v2026.04.10.3
 
 - feat: Oracle Linux package management — rpm list/info, dnf install/update (#5)

--- a/pkg/core/ssh/allowlist.go
+++ b/pkg/core/ssh/allowlist.go
@@ -23,6 +23,7 @@ var defaultAL = Allowlist{
 	"backup":      setOf("rman"),
 	"clusterware": setOf("crsctl", "srvctl", "olsnodes"),
 	"asm":         setOf("asmcmd", "asmca"),
+	"dataguard":   setOf("dgmgrl"),
 	"provision":   setOf("dbca", "netca"),
 	"migration":   setOf("java"),
 	"linux": setOf(

--- a/pkg/core/ssh/ssh_test.go
+++ b/pkg/core/ssh/ssh_test.go
@@ -16,6 +16,7 @@ func TestAllowlistedCommand(t *testing.T) {
 	assert.True(t, exec.IsAllowed("clusterware", "srvctl"))
 	assert.True(t, exec.IsAllowed("asm", "asmcmd"))
 	assert.True(t, exec.IsAllowed("provision", "dbca"))
+	assert.True(t, exec.IsAllowed("dataguard", "dgmgrl"))
 	assert.True(t, exec.IsAllowed("linux", "rpm"))
 }
 


### PR DESCRIPTION
## Summary
- Adds `dataguard` domain with `dgmgrl` to the default SSH allowlist
- Required by dbx-ee P7 Data Guard broker operations (SSH transport for dgmgrl)

Closes #7

## Test plan
- [x] `go test -race ./pkg/core/ssh/` passes
- [x] Test verifies `dataguard`/`dgmgrl` is allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)