### PR TITLE
feat: /dbx-test live integration skill + 3-target test env (#15)

### DIFF
--- a/.claude/skills/dbx-test/SKILL.md
+++ b/.claude/skills/dbx-test/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: dbx-test
+description: Full live integration test suite. Provisions a 3-target test env (Oracle 19c + PG 16 + plain OL9 host) on Proxmox via proxctl, applies OS-level config via linuxctl, runs dbxcli smoke tests against each target, posts results to Slack C0ALHK18VC5, tears down. Use when running /dbx-test or when asked to verify dbx against real targets (dbx#15).
+---
+
+# /dbx-test
+
+Full end-to-end integration test suite for dbx. Provisions real test VMs, runs dbxcli smoke tests, tears down.
+
+## When to use
+
+- CI run: "run dbx live tests"
+- Pre-release verification before tagging dbx
+- Post-bugfix regression check
+- Any user says `/dbx-test`
+
+## Prerequisites (enforced by skill)
+
+- proxctl v2026.04.11.6+ installed and `~/.proxctl/config.yaml` has a working Proxmox context
+- linuxctl v2026.04.11.6+ installed
+- dbxcli + dbx-ee installed and on PATH
+- Vault AppRole credentials loaded (`source ~/.secrets/.env`)
+- Slack webhook in env (`SLACK_WH_DBX_TEST`) — posts to C0ALHK18VC5
+- Test env YAML: `docs/testing/dbx-test-env/env.yaml`
+
+## Steps
+
+1. **Pre-flight** — verify prerequisites; fail fast if anything missing.
+   - `proxctl version` / `linuxctl version` meet minimum CalVer
+   - `proxctl config validate docs/testing/dbx-test-env/env.yaml`
+   - `[ -n "$SLACK_WH_DBX_TEST" ]`
+   - Vault token / AppRole reachable
+2. **Up phase**:
+   - `proxctl workflow up docs/testing/dbx-test-env/env.yaml --yes` (3 VMs concurrent via MultiNodeWorkflow)
+   - Wait for SSH reachable on all 3 nodes (proxctl already blocks until cloud-init done)
+3. **OS layout phase**:
+   - For each node: `linuxctl apply apply docs/testing/dbx-test-env/env.yaml --host <node> --yes`
+   - Verify zero drift: `linuxctl diff docs/testing/dbx-test-env/env.yaml --host <node>` (expect empty)
+   - (Optional) `linuxctl cluster setup-ssh docs/testing/dbx-test-env/env.yaml` for SSH mesh
+4. **dbx target registration**:
+   - For each VM, auto-generate `~/.dbx/targets/<name>.yaml` with connection info (pulls from env.yaml / hypervisor.yaml)
+5. **Smoke tests** (run + collect pass/fail):
+   - Oracle: `dbxcli policy scan -t dbx-test-oracle-19c --profile cis-oracle-19c` — expect CIS findings
+   - Oracle: `dbxcli db session list -t dbx-test-oracle-19c`
+   - Oracle: `dbxcli db tablespace list -t dbx-test-oracle-19c`
+   - PG: `dbxcli pg schema list -t dbx-test-pg-16`
+   - PG: `dbxcli pg connection status -t dbx-test-pg-16`
+   - Host: `dbxcli host info -t dbx-test-plain-ol9` (20 tools — iterate full host subcommand list)
+   - RAG: `dbxcli rag index-status`
+   - Cloud: `dbxcli cloud estimate docs/testing/dbx-test-env/env.yaml --dry-run`
+6. **Slack summary**:
+   - Build a formatted summary: targets up, tests run, pass/fail counts, run duration, snapshot names (if any)
+   - Post to C0ALHK18VC5 via `$SLACK_WH_DBX_TEST`
+7. **Cleanup** (always runs, even on failure):
+   - `proxctl workflow down docs/testing/dbx-test-env/env.yaml --yes` (double-confirm gate auto-acknowledged via --yes)
+   - Remove `~/.dbx/targets/dbx-test-*.yaml`
+   - If apply failed, a snapshot was auto-created (proxctl default); mention snapshot ID in Slack
+
+## Failure modes
+
+- VM provision fails → stop, post failure, teardown anything partial
+- Smoke test fails → continue remaining tests, aggregate failures, teardown
+- Slack unreachable → log locally, don't fail the overall run
+- Teardown fails → post warning; manual cleanup runbook linked
+
+## Exit codes
+
+- 0: all pass
+- 1: any smoke test failed
+- 2: provision/apply/teardown failed
+- 3: prerequisites missing
+
+## Outputs
+
+- `/tmp/dbx-test-<timestamp>/run.log` — full run log
+- `/tmp/dbx-test-<timestamp>/results.json` — pass/fail per test
+- `/tmp/dbx-test-<timestamp>/slack-posted.json` — Slack webhook response
+- Slack message ID posted to C0ALHK18VC5
+
+## References
+
+- Plan: infrastructure/docs/plans/polished-purring-piglet.md
+- Plan (P6): infrastructure#389
+- Env YAML: docs/testing/dbx-test-env/env.yaml
+- Closes: itunified-io/dbx#15

--- a/docs/testing/dbx-test-env/cluster.yaml
+++ b/docs/testing/dbx-test-env/cluster.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+# 3 independent nodes — no RAC, no replication. Each VM is a standalone target
+# registered individually with dbxcli for smoke testing.
+type: plain
+hosts_entries:
+  - ip: 10.10.0.191
+    names: [dbx-test-oracle-19c, dbx-test-oracle-19c.test.itunified.local]
+  - ip: 10.10.0.192
+    names: [dbx-test-pg-16, dbx-test-pg-16.test.itunified.local]
+  - ip: 10.10.0.193
+    names: [dbx-test-plain-ol9, dbx-test-plain-ol9.test.itunified.local]

--- a/docs/testing/dbx-test-env/databases/dbx-test-oracle-19c.yaml
+++ b/docs/testing/dbx-test-env/databases/dbx-test-oracle-19c.yaml
@@ -1,0 +1,18 @@
+kind: Database
+name: dbx-test-oracle-19c
+engine: oracle
+version: "19c"
+node: dbx-test-oracle-19c
+connection:
+  host: 10.10.0.191
+  port: 1521
+  service_name: ORCLPDB1
+  username: system
+  password: ${vault:secret/dbx-test/oracle-19c/system_password}
+dbx_target:
+  type: oracle
+  profile: cis-oracle-19c
+provisioning:
+  data_dir: /u01/app/oracle/oradata
+  sga_target_mb: 2048
+  pga_aggregate_target_mb: 512

--- a/docs/testing/dbx-test-env/databases/dbx-test-pg-16.yaml
+++ b/docs/testing/dbx-test-env/databases/dbx-test-pg-16.yaml
@@ -1,0 +1,18 @@
+kind: Database
+name: dbx-test-pg-16
+engine: postgresql
+version: "16"
+node: dbx-test-pg-16
+connection:
+  host: 10.10.0.192
+  port: 5432
+  database: dbx_test
+  username: dbx_test
+  password: ${vault:secret/dbx-test/pg-16/dbx_test_password}
+dbx_target:
+  type: postgresql
+  profile: cis-postgresql-16
+provisioning:
+  data_dir: /var/lib/pgsql/16/data
+  shared_buffers: 256MB
+  max_connections: 100

--- a/docs/testing/dbx-test-env/env.yaml
+++ b/docs/testing/dbx-test-env/env.yaml
@@ -1,0 +1,35 @@
+# dbx-test — 3-target live integration test env.
+#
+# Provisioned by /dbx-test skill. Three independent nodes (no RAC / no CNPG):
+#   - dbx-test-oracle-19c   — OL9 + Oracle 19c single-instance
+#   - dbx-test-pg-16        — Ubuntu 22.04 + PostgreSQL 16
+#   - dbx-test-plain-ol9    — OL9, no DB (host-monitor tests only)
+#
+# Validate:  proxctl config validate docs/testing/dbx-test-env/env.yaml
+# Up:        proxctl workflow up  docs/testing/dbx-test-env/env.yaml --yes
+# Apply OS:  linuxctl apply apply docs/testing/dbx-test-env/env.yaml --host <node> --yes
+# Down:      proxctl workflow down docs/testing/dbx-test-env/env.yaml --yes
+#
+# All tags carry `lifetime: 4h` — any stray VM older than 4h should be pruned
+# by the housekeeper cron.
+version: "1"
+kind: Env
+metadata:
+  name: dbx-test
+  domain: test.itunified.local
+  proxmox_context: proximo01
+  dbx_context: dbx-test
+  tags:
+    owner: dbx-ci
+    env: test
+    lifetime: 4h
+  description: 3-target dbx live integration test env (Oracle 19c + PG 16 + plain OL9).
+spec:
+  hypervisor:      { $ref: ./hypervisor.yaml }
+  linux:           { $ref: ./linux.yaml }
+  networks:        { $ref: ./networks.yaml }
+  storage_classes: { $ref: ./storage-classes.yaml }
+  cluster:         { $ref: ./cluster.yaml }
+databases:
+  - { $ref: ./databases/dbx-test-oracle-19c.yaml }
+  - { $ref: ./databases/dbx-test-pg-16.yaml }

--- a/docs/testing/dbx-test-env/hypervisor.yaml
+++ b/docs/testing/dbx-test-env/hypervisor.yaml
@@ -1,0 +1,107 @@
+kind: Hypervisor
+defaults:
+  resources:
+    memory: 4096
+    cores: 2
+    sockets: 1
+  tags: [proxctl, dbx-test, ci]
+nodes:
+  dbx-test-oracle-19c:
+    proxmox:
+      node_name: proximo01
+      vm_id: 2901
+    resources:
+      memory: 8192
+      cores: 4
+      sockets: 1
+    ips:
+      public: 10.10.0.191
+    nics:
+      - name: net0
+        usage: public
+        bridge: vmbr0
+        network: public
+        ipv4:
+          address: 10.10.0.191/24
+          gateway: 10.10.0.1
+          dns: [10.10.0.1]
+    disks:
+      - id: 0
+        size: 64G
+        storage_class: local-lvm
+        interface: scsi0
+        role: root
+      - id: 1
+        size: 80G
+        storage_class: local-lvm
+        interface: scsi1
+        role: oracle-data
+        tag: oracle-data
+  dbx-test-pg-16:
+    proxmox:
+      node_name: proximo01
+      vm_id: 2902
+    ips:
+      public: 10.10.0.192
+    nics:
+      - name: net0
+        usage: public
+        bridge: vmbr0
+        network: public
+        ipv4:
+          address: 10.10.0.192/24
+          gateway: 10.10.0.1
+          dns: [10.10.0.1]
+    disks:
+      - id: 0
+        size: 32G
+        storage_class: local-lvm
+        interface: scsi0
+        role: root
+      - id: 1
+        size: 40G
+        storage_class: local-lvm
+        interface: scsi1
+        role: pg-data
+        tag: pg-data
+  dbx-test-plain-ol9:
+    proxmox:
+      node_name: proximo01
+      vm_id: 2903
+    ips:
+      public: 10.10.0.193
+    nics:
+      - name: net0
+        usage: public
+        bridge: vmbr0
+        network: public
+        ipv4:
+          address: 10.10.0.193/24
+          gateway: 10.10.0.1
+          dns: [10.10.0.1]
+    disks:
+      - id: 0
+        size: 32G
+        storage_class: local-lvm
+        interface: scsi0
+        role: root
+iso:
+  storage: local
+  image: OracleLinux-R9-U3-x86_64-dvd.iso
+  guest_os_type: l26
+kickstart:
+  distro: oraclelinux9
+  timezone: Europe/Berlin
+  lang: en_US.UTF-8
+  mode: text
+  chrony_servers: [0.pool.ntp.org, 1.pool.ntp.org]
+  sudo:
+    wheel_nopasswd: true
+  packages:
+    base: [chrony, qemu-guest-agent, cifs-utils]
+  firewall:
+    enabled: false
+  update_system: true
+  ssh_keys:
+    root:
+      - ${env:DBX_CI_SSH_PUBKEY}

--- a/docs/testing/dbx-test-env/linux.yaml
+++ b/docs/testing/dbx-test-env/linux.yaml
@@ -1,0 +1,27 @@
+kind: Linux
+# Shared OS layout for all three nodes. Per-node overrides handled by
+# linuxctl's --host flag (partitions only apply if disk_tag exists on the node).
+partitions:
+  - disk_tag: oracle-data
+    filesystem: xfs
+    mountpoint: /u01
+  - disk_tag: pg-data
+    filesystem: xfs
+    mountpoint: /var/lib/pgsql
+users:
+  - name: dbxtest
+    wheel: true
+    ssh_key: ${env:DBX_CI_SSH_PUBKEY}
+directories:
+  - path: /opt/dbx
+    owner: dbxtest
+    group: dbxtest
+    mode: "0755"
+packages:
+  - chrony
+  - qemu-guest-agent
+  - cifs-utils
+services:
+  - name: chronyd
+    state: started
+    enabled: true

--- a/docs/testing/dbx-test-env/networks.yaml
+++ b/docs/testing/dbx-test-env/networks.yaml
@@ -1,0 +1,5 @@
+kind: Networks
+public:
+  cidr: 10.10.0.0/24
+  gateway: 10.10.0.1
+  dns: [10.10.0.1]

--- a/docs/testing/dbx-test-env/storage-classes.yaml
+++ b/docs/testing/dbx-test-env/storage-classes.yaml
@@ -1,0 +1,4 @@
+kind: StorageClasses
+local-lvm:
+  backend: lvm-thin
+  shared: false


### PR DESCRIPTION
## Summary

- Adds `/dbx-test` Claude Code skill (`.claude/skills/dbx-test/SKILL.md`) that orchestrates: proxctl workflow up → linuxctl apply → dbxcli smoke tests (policy / db / pg / host / rag / cloud) → Slack summary to C0ALHK18VC5 → proxctl workflow down.
- Adds a 3-target test env under `docs/testing/dbx-test-env/` (Oracle 19c + PG 16 + plain OL9) using the split layer-file architecture (env / hypervisor / linux / networks / storage-classes / cluster + 2 databases).
- No secrets in YAML — uses `${env:...}` / `${vault:...}` placeholders.

## Validation

- `proxctl config validate docs/testing/dbx-test-env/env.yaml` → `OK: dbx-test (version=1, kind=Env)` (with `DBX_CI_SSH_PUBKEY` set).
- Closes itunified-io/dbx#15 once a real /dbx-test run posts to Slack.

## Test plan

- [ ] Run `/dbx-test` once proxctl/linuxctl are installed on the runner.
- [ ] Verify all 3 VMs provision on proximo01 (VM IDs 2901-2903).
- [ ] Verify zero drift after `linuxctl apply`.
- [ ] Verify Slack summary in C0ALHK18VC5.
- [ ] Verify clean teardown.

Refs: itunified-io/infrastructure#389 (Phase 6)
Closes: #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)