### PR TITLE
feat(provision): 8 Oracle install primitives (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2026.05.01.1 — 2026-05-01
+
+### feat(provision): pkg/provision/install — 8 Oracle install primitives (#22)
+
+New `dbxcli provision install …` subcommands wrapping Oracle silent
+installs end-to-end. Plan 0a of the /lab-up Phase D + E master plan
+(infrastructure issue #519).
+
+Primitives (Cobra leaves):
+- install grid       — runInstaller silent for Grid Infrastructure
+- install dbhome     — runInstaller silent for Oracle DB home
+- install root-sh    — root.sh execution + idempotency touchfile
+- install asmca      — asmca silent diskgroup creation
+- install netca      — netca silent listener creation
+- install asm-label  — oracleasm/AFD disk labeling
+- install dbca       — DBCA silent CDB creation
+- install pdb        — DBCA silent PDB creation
+
+All primitives:
+- Idempotent (detect-and-skip via two-phase sentinel for non-idempotent
+  ops; touchfile for idempotent root.sh)
+- ctx-cancel safe (mid-run interrupt → DetectionStatePartial)
+- Version-agnostic detection (no version-string substring matches)
+- Shell-injection hardened (control-char + metachar Validate; shellEscape
+  on every interpolated arg)
+- `env ORACLE_HOME=<home> <home>/bin/<bin>` qualified probes
+- `--reset` MVP non-destructive (prints recovery runbook to stderr)
+- OTEL span per invocation with `dbx.*` attributes via the package-level
+  `otel.GlobalExporter()` (Plan 0a Task 10)
+
+E2E coverage:
+- Per-primitive unit tests with `host/hosttest.MockExecutor`
+- `pkg/provision/install/otel_test.go` — capture-exporter verifies span
+  emission for all 8 primitives (StatusOK + StatusError paths)
+- `cmd/dbxcli/root/provision_install_e2e_test.go` — leaf registration,
+  --help renders, required-flag rejection (Plan 0a Task 12)
+
+Deferred to follow-ups:
+- Audit chain integration (#26 — dbx `pkg/audit/` doesn't exist yet)
+- License gate enforcement (#27 — `pkg/license/` doesn't expose
+  `RequireBundle` yet; TODO markers remain in `provision_install.go`)
+
 ## v2026.04.30.1
 
 ### feat: pkg/otel + Target.OTELAttrs (#19)

--- a/cmd/dbxcli/root/provision.go
+++ b/cmd/dbxcli/root/provision.go
@@ -28,5 +28,6 @@ Use 'dbxcli provision install --help' for install primitives,
 'dbxcli provision pdb --help' for PDB lifecycle.`,
 	}
 	cmd.PersistentFlags().String("target", "", "target name (from ~/.dbx/targets/)")
+	cmd.AddCommand(NewInstallCmd())
 	return cmd
 }

--- a/cmd/dbxcli/root/provision.go
+++ b/cmd/dbxcli/root/provision.go
@@ -1,0 +1,32 @@
+package root
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewProvisionCmd returns the parent cobra.Command for all
+// `dbxcli provision …` subcommands.
+//
+// Subcommands:
+//   - install    Phase D install primitives (grid, dbhome, root-sh,
+//                asmca, netca, asm-label)
+//   - dbca       Database creation/configuration (create-db, …)
+//   - pdb        PDB lifecycle (create, …)
+//
+// Per ADR-0094, all provision actions require Enterprise tier; the gate
+// is enforced at each leaf subcommand's RunE (not here, so `--help`
+// works without a license).
+func NewProvisionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "provision",
+		Short: "Database/host provisioning primitives (Enterprise)",
+		Long: `Provisioning primitives invoked by /lab-up Phase D skills
+(infrastructure repo). All actions require Enterprise license.
+
+Use 'dbxcli provision install --help' for install primitives,
+'dbxcli provision dbca --help' for database creation,
+'dbxcli provision pdb --help' for PDB lifecycle.`,
+	}
+	cmd.PersistentFlags().String("target", "", "target name (from ~/.dbx/targets/)")
+	return cmd
+}

--- a/cmd/dbxcli/root/provision_install.go
+++ b/cmd/dbxcli/root/provision_install.go
@@ -24,6 +24,7 @@ func NewInstallCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newInstallGridCmd())
 	cmd.AddCommand(newInstallDbhomeCmd())
+	cmd.AddCommand(newInstallRootshCmd())
 	return cmd
 }
 
@@ -63,6 +64,41 @@ func newInstallDbhomeCmd() *cobra.Command {
 	cmd.Flags().StringVar(&spec.SoftwareStaging, "software-staging", "", "Path on host where DB home software is unzipped")
 	cmd.Flags().StringVar(&spec.ResponseFilePath, "response-file", "", "Absolute path on host to rendered .rsp file")
 	cmd.Flags().BoolVar(&reset, "reset", false, "Reset prior install state (NOT IMPLEMENTED YET)")
+	_ = cmd.MarkFlagRequired("oracle-home")
+	return cmd
+}
+
+// newInstallRootshCmd: dbxcli provision install root-sh --target X --oracle-home Y [--reset]
+func newInstallRootshCmd() *cobra.Command {
+	var (
+		spec  install.InstallSpec
+		reset bool
+	)
+	cmd := &cobra.Command{
+		Use:   "root-sh",
+		Short: "Run <OracleHome>/root.sh idempotently after a runInstaller",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			if spec.Target == "" {
+				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
+					spec.Target = pt.Value.String()
+				}
+			}
+			res, err := install.RootSh(context.Background(), spec, reset)
+			if err != nil {
+				return err
+			}
+			out, err := json.MarshalIndent(res, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&spec.Target, "target", "", "target name (overrides provision --target)")
+	cmd.Flags().StringVar(&spec.OracleHome, "oracle-home", "", "$ORACLE_HOME or $GRID_HOME containing root.sh")
+	cmd.Flags().BoolVar(&reset, "reset", false, "Re-run root.sh even if touchfile exists (root.sh is idempotent)")
 	_ = cmd.MarkFlagRequired("oracle-home")
 	return cmd
 }

--- a/cmd/dbxcli/root/provision_install.go
+++ b/cmd/dbxcli/root/provision_install.go
@@ -21,7 +21,7 @@ import (
 func NewInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
-		Short: "Oracle install primitives (grid, dbhome, root-sh, asmca, netca, asm-label)",
+		Short: "Oracle install primitives (grid, dbhome, root-sh, asmca, netca, asm-label, dbca, pdb)",
 	}
 	cmd.AddCommand(newInstallGridCmd())
 	cmd.AddCommand(newInstallDbhomeCmd())
@@ -30,6 +30,83 @@ func NewInstallCmd() *cobra.Command {
 	cmd.AddCommand(newInstallNetcaCmd())
 	cmd.AddCommand(newInstallAsmLabelCmd())
 	cmd.AddCommand(newInstallDbcaCmd())
+	cmd.AddCommand(newInstallPdbCmd())
+	return cmd
+}
+
+// newInstallPdbCmd: dbxcli provision install pdb --target X --oracle-home Y --oracle-base Z --cdb-name ORCL --pdb-name PDB1 --admin-password-file F [--datafile-dest +DATA] [--response-file W] [--reset]
+func newInstallPdbCmd() *cobra.Command {
+	var (
+		spec  install.PdbCreateSpec
+		reset bool
+	)
+	cmd := &cobra.Command{
+		Use:   "pdb",
+		Short: "Create a PDB via dbca -silent -createPluggableDatabase (two-phase sentinel)",
+		Long: `Create an Oracle Pluggable Database via dbca silent. Phase D.5 of
+/lab-up — runs after the parent CDB exists (Phase D.4 dbca
+-createDatabase) and before any PDB-scoped tooling.
+
+Idempotency: NON-IDEMPOTENT primitive — uses a two-phase sentinel
+(<oracle_base>/cfgtoollogs/dbx/pdb.<CDB>.<PDB>.partial → pdb.<CDB>.<PDB>.installed),
+keyed on (parent CDB, new PDB) so same-PDB-name in different CDBs on
+the same host does not collide. Detection ALSO probes
+` + "`select name from v$pdbs where name = upper('<PDB>')`" + ` so a
+pre-existing PDB is recognised without forcing a sentinel.
+
+Two CLI shapes are supported:
+  - Direct CLI (default): -sourceDB <CDB> -pdbName <PDB>
+    -pdbAdminUserName PDBADMIN -pdbAdminPasswordFile <file>
+    [-pdbDatafileDestination <dest>]
+  - Response-file (--response-file <rsp>): for advanced templates.
+
+Passwords are NEVER on the command line — dbca reads
+-pdbAdminPasswordFile from a 0600 file owned by the oracle user that
+the caller (skill) placed before invocation.
+
+Reset (MVP): --reset on installed/partial state prints a manual
+recovery runbook to stderr and skips. The destructive
+` + "`dbca -silent -deletePluggableDatabase`" + ` step is deferred to a
+reverter follow-up plan.`,
+		Example: `  dbxcli provision install pdb --target ext3adm1 \
+    --oracle-home /u01/app/oracle/product/19c/dbhome_1 \
+    --oracle-base /u01/app/oracle \
+    --cdb-name ORCL --pdb-name PDB1 \
+    --admin-password-file /tmp/pdbadmin.pw \
+    --datafile-dest +DATA`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			if spec.Target == "" {
+				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
+					spec.Target = pt.Value.String()
+				}
+			}
+			res, err := install.PdbCreate(context.Background(), spec, reset)
+			if err != nil {
+				return err
+			}
+			out, err := json.MarshalIndent(res, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&spec.Target, "target", "", "target name (overrides provision --target)")
+	cmd.Flags().StringVar(&spec.OracleHome, "oracle-home", "", "$ORACLE_HOME containing bin/dbca + bin/sqlplus")
+	cmd.Flags().StringVar(&spec.OracleBase, "oracle-base", "", "$ORACLE_BASE (sentinel root)")
+	cmd.Flags().StringVar(&spec.CdbName, "cdb-name", "", "Parent CDB DB_UNIQUE_NAME (sentinel key + sqlplus probe target)")
+	cmd.Flags().StringVar(&spec.PdbName, "pdb-name", "", "New PDB name")
+	cmd.Flags().StringVar(&spec.AdminPasswordFile, "admin-password-file", "", "Absolute path to file on host containing PDB admin password (mode 0600)")
+	cmd.Flags().StringVar(&spec.DatafileDest, "datafile-dest", "", "Optional: ASM diskgroup (+DATA) or absolute filesystem path for PDB datafiles")
+	cmd.Flags().StringVar(&spec.ResponseFilePath, "response-file", "", "Optional: absolute path on host to rendered dbca .rsp (overrides direct-CLI form)")
+	cmd.Flags().BoolVar(&reset, "reset", false, "Print manual recovery runbook (NON-DESTRUCTIVE in MVP)")
+	_ = cmd.MarkFlagRequired("oracle-home")
+	_ = cmd.MarkFlagRequired("oracle-base")
+	_ = cmd.MarkFlagRequired("cdb-name")
+	_ = cmd.MarkFlagRequired("pdb-name")
+	_ = cmd.MarkFlagRequired("admin-password-file")
 	return cmd
 }
 

--- a/cmd/dbxcli/root/provision_install.go
+++ b/cmd/dbxcli/root/provision_install.go
@@ -29,6 +29,72 @@ func NewInstallCmd() *cobra.Command {
 	cmd.AddCommand(newInstallAsmcaCmd())
 	cmd.AddCommand(newInstallNetcaCmd())
 	cmd.AddCommand(newInstallAsmLabelCmd())
+	cmd.AddCommand(newInstallDbcaCmd())
+	return cmd
+}
+
+// newInstallDbcaCmd: dbxcli provision install dbca --target X --oracle-home Y --oracle-base Z --response-file W --db-unique-name ORCL [--sys-password-file F] [--system-password-file F] [--reset]
+func newInstallDbcaCmd() *cobra.Command {
+	var (
+		spec  install.DbcaCreateDbSpec
+		reset bool
+	)
+	cmd := &cobra.Command{
+		Use:   "dbca",
+		Short: "Create CDB via dbca -silent -createDatabase (two-phase sentinel)",
+		Long: `Create an Oracle CDB via dbca silent. Phase D.4 of /lab-up — runs after
+Grid + DB Home + listener and before PDB creation / Data Guard standby
+cloning.
+
+Idempotency: NON-IDEMPOTENT primitive — uses a two-phase sentinel
+(<oracle_base>/cfgtoollogs/dbx/dbca.<DB_UNIQUE_NAME>.partial → dbca.<DB_UNIQUE_NAME>.installed).
+Detection ALSO probes ` + "`srvctl status database -d <unique>`" + ` so a
+pre-existing database is recognised without forcing a sentinel.
+
+The caller (skill) is responsible for rendering and SCPing the dbca .rsp
+response file to the target host before invoking this command. The
+response file format is multi-version; the skill picks the correct
+template per Oracle release (19c / 23ai / 26ai).
+
+Reset (MVP): --reset on installed/partial state prints a manual recovery
+runbook to stderr and skips. The destructive ` + "`dbca -silent -deleteDatabase`" + `
+step is deferred to a reverter follow-up plan.`,
+		Example: `  dbxcli provision install dbca --target ext3adm1 \
+    --oracle-home /u01/app/oracle/product/19c/dbhome_1 \
+    --oracle-base /u01/app/oracle \
+    --response-file /tmp/dbca.rsp \
+    --db-unique-name ORCL`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			if spec.Target == "" {
+				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
+					spec.Target = pt.Value.String()
+				}
+			}
+			res, err := install.DbcaCreateDb(context.Background(), spec, reset)
+			if err != nil {
+				return err
+			}
+			out, err := json.MarshalIndent(res, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&spec.Target, "target", "", "target name (overrides provision --target)")
+	cmd.Flags().StringVar(&spec.OracleHome, "oracle-home", "", "$ORACLE_HOME containing bin/dbca + bin/srvctl")
+	cmd.Flags().StringVar(&spec.OracleBase, "oracle-base", "", "$ORACLE_BASE (sentinel root)")
+	cmd.Flags().StringVar(&spec.ResponseFilePath, "response-file", "", "Absolute path on host to rendered dbca .rsp")
+	cmd.Flags().StringVar(&spec.DbUniqueName, "db-unique-name", "", "DB_UNIQUE_NAME (used as sentinel key + srvctl probe target)")
+	cmd.Flags().StringVar(&spec.SysPasswordFile, "sys-password-file", "", "Optional: absolute path to file on host containing SYS password (mode 0600)")
+	cmd.Flags().StringVar(&spec.SystemPasswordFile, "system-password-file", "", "Optional: absolute path to file on host containing SYSTEM password (mode 0600)")
+	cmd.Flags().BoolVar(&reset, "reset", false, "Print manual recovery runbook (NON-DESTRUCTIVE in MVP)")
+	_ = cmd.MarkFlagRequired("oracle-home")
+	_ = cmd.MarkFlagRequired("oracle-base")
+	_ = cmd.MarkFlagRequired("response-file")
+	_ = cmd.MarkFlagRequired("db-unique-name")
 	return cmd
 }
 

--- a/cmd/dbxcli/root/provision_install.go
+++ b/cmd/dbxcli/root/provision_install.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/itunified-io/dbx/pkg/provision/install"
 	"github.com/spf13/cobra"
@@ -25,6 +26,70 @@ func NewInstallCmd() *cobra.Command {
 	cmd.AddCommand(newInstallGridCmd())
 	cmd.AddCommand(newInstallDbhomeCmd())
 	cmd.AddCommand(newInstallRootshCmd())
+	cmd.AddCommand(newInstallAsmcaCmd())
+	return cmd
+}
+
+// newInstallAsmcaCmd: dbxcli provision install asmca --target X --oracle-home Y --oracle-base Z --dg-name DATA --disks /dev/sdb,/dev/sdc [--redundancy EXTERNAL] [--au-size-mb 4] [--reset]
+func newInstallAsmcaCmd() *cobra.Command {
+	var (
+		spec       install.AsmcaSpec
+		disksFlag  string
+		reset      bool
+	)
+	cmd := &cobra.Command{
+		Use:   "asmca",
+		Short: "Create initial ASM diskgroup via asmca -silent (two-phase sentinel)",
+		Long: `Create the initial ASM diskgroup (DATA, RECO) for an Oracle Grid Infrastructure
+installation. Subsequent diskgroup operations should go through the
+mcp-oracle-ee-asm tools, which assume ASM is already up.
+
+Idempotency: NON-IDEMPOTENT primitive — uses a two-phase sentinel
+(<oracle_base>/cfgtoollogs/dbx/asmca.<DG>.partial → asmca.<DG>.installed).
+Detection is version-agnostic.
+
+Reset (MVP): --reset on installed/partial state prints a manual recovery
+runbook to stderr and skips. The destructive ` + "`drop diskgroup`" + ` step is
+deferred to a reverter follow-up plan.`,
+		Example: `  dbxcli provision install asmca --target ext3adm1 \
+    --oracle-home /u01/app/19c/grid \
+    --oracle-base /u01/app/grid \
+    --dg-name DATA --disks /dev/sdb,/dev/sdc \
+    --redundancy EXTERNAL --au-size-mb 4`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			if spec.Target == "" {
+				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
+					spec.Target = pt.Value.String()
+				}
+			}
+			if disksFlag == "" {
+				return fmt.Errorf("--disks is required (comma-separated)")
+			}
+			spec.Disks = strings.Split(disksFlag, ",")
+			res, err := install.AsmcaSilent(context.Background(), spec, reset)
+			if err != nil {
+				return err
+			}
+			out, err := json.MarshalIndent(res, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&spec.Target, "target", "", "target name (overrides provision --target)")
+	cmd.Flags().StringVar(&spec.OracleHome, "oracle-home", "", "$GRID_HOME containing bin/asmca")
+	cmd.Flags().StringVar(&spec.OracleBase, "oracle-base", "", "$ORACLE_BASE for grid (sentinel root)")
+	cmd.Flags().StringVar(&spec.DGName, "dg-name", "", "Diskgroup name (e.g. DATA)")
+	cmd.Flags().StringVar(&spec.Redundancy, "redundancy", "EXTERNAL", "EXTERNAL | NORMAL | HIGH")
+	cmd.Flags().IntVar(&spec.AUSizeMB, "au-size-mb", 4, "Allocation Unit size in MB")
+	cmd.Flags().StringVar(&disksFlag, "disks", "", "Comma-separated disk paths or AFD labels")
+	cmd.Flags().BoolVar(&reset, "reset", false, "Print manual recovery runbook (NON-DESTRUCTIVE in MVP)")
+	_ = cmd.MarkFlagRequired("oracle-home")
+	_ = cmd.MarkFlagRequired("oracle-base")
+	_ = cmd.MarkFlagRequired("dg-name")
 	return cmd
 }
 

--- a/cmd/dbxcli/root/provision_install.go
+++ b/cmd/dbxcli/root/provision_install.go
@@ -23,6 +23,47 @@ func NewInstallCmd() *cobra.Command {
 		Short: "Oracle install primitives (grid, dbhome, root-sh, asmca, netca, asm-label)",
 	}
 	cmd.AddCommand(newInstallGridCmd())
+	cmd.AddCommand(newInstallDbhomeCmd())
+	return cmd
+}
+
+// newInstallDbhomeCmd: dbxcli provision install dbhome --target X --oracle-home Y --software-staging Z --response-file W [--reset]
+func newInstallDbhomeCmd() *cobra.Command {
+	var (
+		spec  install.InstallSpec
+		reset bool
+	)
+	cmd := &cobra.Command{
+		Use:   "dbhome",
+		Short: "Run runInstaller -silent for Oracle DB Home 19c",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			// spec.Target is bound directly via --target flag; inherit from parent
+			// persistent flag if not set on this leaf.
+			if spec.Target == "" {
+				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
+					spec.Target = pt.Value.String()
+				}
+			}
+			res, err := install.DBHomeInstall(context.Background(), spec, reset)
+			if err != nil {
+				return err
+			}
+			out, err := json.MarshalIndent(res, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&spec.Target, "target", "", "target name (overrides provision --target)")
+	cmd.Flags().StringVar(&spec.OracleHome, "oracle-home", "", "$ORACLE_HOME (e.g. /u01/app/oracle/product/19c/dbhome_1)")
+	cmd.Flags().StringVar(&spec.OracleBase, "oracle-base", "", "$ORACLE_BASE (e.g. /u01/app/oracle)")
+	cmd.Flags().StringVar(&spec.SoftwareStaging, "software-staging", "", "Path on host where DB home software is unzipped")
+	cmd.Flags().StringVar(&spec.ResponseFilePath, "response-file", "", "Absolute path on host to rendered .rsp file")
+	cmd.Flags().BoolVar(&reset, "reset", false, "Reset prior install state (NOT IMPLEMENTED YET)")
+	_ = cmd.MarkFlagRequired("oracle-home")
 	return cmd
 }
 

--- a/cmd/dbxcli/root/provision_install.go
+++ b/cmd/dbxcli/root/provision_install.go
@@ -27,6 +27,66 @@ func NewInstallCmd() *cobra.Command {
 	cmd.AddCommand(newInstallDbhomeCmd())
 	cmd.AddCommand(newInstallRootshCmd())
 	cmd.AddCommand(newInstallAsmcaCmd())
+	cmd.AddCommand(newInstallNetcaCmd())
+	return cmd
+}
+
+// newInstallNetcaCmd: dbxcli provision install netca --target X --oracle-home Y --oracle-base Z --response-file W [--listener-name LISTENER] [--port 1521] [--reset]
+func newInstallNetcaCmd() *cobra.Command {
+	var (
+		spec  install.NetcaSpec
+		reset bool
+	)
+	cmd := &cobra.Command{
+		Use:   "netca",
+		Short: "Create Oracle listener via netca -silent (two-phase sentinel)",
+		Long: `Create an Oracle Net listener via netca silent. Used during Phase D.2
+(post-Grid, pre-DBCA) to ensure a LISTENER exists for client connections
+AND during Phase E.2 to add static services on a standby for RMAN
+DUPLICATE FROM ACTIVE.
+
+Idempotency: NON-IDEMPOTENT primitive — uses a two-phase sentinel
+(<oracle_base>/cfgtoollogs/dbx/netca.<LISTENER>.partial → netca.<LISTENER>.installed).
+Detection ALSO probes lsnrctl status so a pre-existing listener is
+recognised without forcing a sentinel.
+
+Reset (MVP): --reset on installed/partial state prints a manual recovery
+runbook to stderr and skips. The destructive listener-drop step is
+deferred to a reverter follow-up plan.`,
+		Example: `  dbxcli provision install netca --target ext3adm1 \
+    --oracle-home /u01/app/oracle/product/19c/dbhome_1 \
+    --oracle-base /u01/app/oracle \
+    --response-file /tmp/netca.rsp \
+    --listener-name LISTENER --port 1521`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			if spec.Target == "" {
+				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
+					spec.Target = pt.Value.String()
+				}
+			}
+			res, err := install.NetcaSilent(context.Background(), spec, reset)
+			if err != nil {
+				return err
+			}
+			out, err := json.MarshalIndent(res, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&spec.Target, "target", "", "target name (overrides provision --target)")
+	cmd.Flags().StringVar(&spec.OracleHome, "oracle-home", "", "$ORACLE_HOME containing bin/netca + bin/lsnrctl")
+	cmd.Flags().StringVar(&spec.OracleBase, "oracle-base", "", "$ORACLE_BASE (sentinel root)")
+	cmd.Flags().StringVar(&spec.ResponseFilePath, "response-file", "", "Absolute path on host to rendered netca .rsp")
+	cmd.Flags().StringVar(&spec.ListenerName, "listener-name", "LISTENER", "Listener name")
+	cmd.Flags().IntVar(&spec.Port, "port", 1521, "TCP listening port")
+	cmd.Flags().BoolVar(&reset, "reset", false, "Print manual recovery runbook (NON-DESTRUCTIVE in MVP)")
+	_ = cmd.MarkFlagRequired("oracle-home")
+	_ = cmd.MarkFlagRequired("oracle-base")
+	_ = cmd.MarkFlagRequired("response-file")
 	return cmd
 }
 

--- a/cmd/dbxcli/root/provision_install.go
+++ b/cmd/dbxcli/root/provision_install.go
@@ -28,6 +28,86 @@ func NewInstallCmd() *cobra.Command {
 	cmd.AddCommand(newInstallRootshCmd())
 	cmd.AddCommand(newInstallAsmcaCmd())
 	cmd.AddCommand(newInstallNetcaCmd())
+	cmd.AddCommand(newInstallAsmLabelCmd())
+	return cmd
+}
+
+// newInstallAsmLabelCmd: dbxcli provision install asm-label --target X --grid-home Y --oracle-base Z --impl asmlib|afd --labels DATA1:/dev/sdb,DATA2:/dev/sdc [--reset]
+func newInstallAsmLabelCmd() *cobra.Command {
+	var (
+		spec       install.AsmDiskLabelSpec
+		labelsFlag string
+		reset      bool
+	)
+	cmd := &cobra.Command{
+		Use:   "asm-label",
+		Short: "Label raw disks for ASM discovery (asmlib or AFD; per-label two-phase sentinel)",
+		Long: `Label raw block devices via ASMlib (oracleasm) or Oracle ASM Filter
+Driver (AFD) so the disks become discoverable as ASM disks. This is a
+Phase D.1 prerequisite that runs BEFORE asmca (which creates the
+diskgroup over labeled devices).
+
+Idempotency: NON-IDEMPOTENT primitive — uses a per-label two-phase
+sentinel (<oracle_base>/cfgtoollogs/dbx/asm-label.<NAME>.partial →
+asm-label.<NAME>.installed). Detection ALSO probes oracleasm listdisks
+(asmlib) or asmcmd afd_lslbl <device> (afd) so a pre-existing label is
+recognised without forcing a sentinel.
+
+Reset (MVP): --reset on installed/partial state for any label prints a
+manual recovery runbook to stderr and skips that label. The destructive
+label-removal step is deferred to a reverter follow-up plan.`,
+		Example: `  dbxcli provision install asm-label --target ext3adm1 \
+    --grid-home /u01/app/19c/grid \
+    --oracle-base /u01/app/grid \
+    --impl asmlib \
+    --labels DATA1:/dev/sdb,DATA2:/dev/sdc`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			if spec.Target == "" {
+				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
+					spec.Target = pt.Value.String()
+				}
+			}
+			if labelsFlag == "" {
+				return fmt.Errorf("--labels is required (comma-separated NAME:DEVICE pairs)")
+			}
+			for _, pair := range strings.Split(labelsFlag, ",") {
+				parts := strings.SplitN(pair, ":", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("--labels pair %q must be NAME:DEVICE", pair)
+				}
+				spec.Labels = append(spec.Labels, install.AsmLabelEntry{
+					Name:   parts[0],
+					Device: parts[1],
+				})
+			}
+			res, err := install.AsmDiskLabel(context.Background(), spec, reset)
+			if err != nil {
+				// Print partial result before returning so operators see
+				// per-label state on failure.
+				if res != nil {
+					out, _ := json.MarshalIndent(res, "", "  ")
+					fmt.Println(string(out))
+				}
+				return err
+			}
+			out, err := json.MarshalIndent(res, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&spec.Target, "target", "", "target name (overrides provision --target)")
+	cmd.Flags().StringVar(&spec.GridHome, "grid-home", "", "$GRID_HOME containing bin/asmcmd (used for AFD; required for both impls)")
+	cmd.Flags().StringVar(&spec.OracleBase, "oracle-base", "", "$ORACLE_BASE for grid (sentinel root)")
+	cmd.Flags().StringVar(&spec.Implementation, "impl", install.AsmDiskLabelImplAFD, "Labeling implementation: asmlib | afd")
+	cmd.Flags().StringVar(&labelsFlag, "labels", "", "Comma-separated NAME:DEVICE pairs (e.g. DATA1:/dev/sdb,DATA2:/dev/sdc)")
+	cmd.Flags().BoolVar(&reset, "reset", false, "Print manual recovery runbook (NON-DESTRUCTIVE in MVP)")
+	_ = cmd.MarkFlagRequired("grid-home")
+	_ = cmd.MarkFlagRequired("oracle-base")
+	_ = cmd.MarkFlagRequired("labels")
 	return cmd
 }
 

--- a/cmd/dbxcli/root/provision_install.go
+++ b/cmd/dbxcli/root/provision_install.go
@@ -10,6 +10,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// resolveTarget returns the leaf-local --target if set, else the inherited
+// parent persistent --target, else a usage error. The error is intended to
+// surface BEFORE Validate so the caller sees a cobra-style "required flag"
+// message instead of a deeper runtime spec.Validate() failure.
+func resolveTarget(cmd *cobra.Command, localTarget string) (string, error) {
+	if localTarget != "" {
+		return localTarget, nil
+	}
+	if p := cmd.InheritedFlags().Lookup("target"); p != nil && p.Value.String() != "" {
+		return p.Value.String(), nil
+	}
+	return "", fmt.Errorf("required flag --target not set (pass on leaf or on parent provision command)")
+}
+
 // NewInstallCmd returns the `provision install` parent subcommand.
 // Each leaf delegates to a function in dbx/pkg/provision/install/.
 //
@@ -76,11 +90,11 @@ reverter follow-up plan.`,
     --datafile-dest +DATA`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// TODO(#519): wire license.RequireBundle("provision") once helper ships
-			if spec.Target == "" {
-				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
-					spec.Target = pt.Value.String()
-				}
+			t, err := resolveTarget(cmd, spec.Target)
+			if err != nil {
+				return err
 			}
+			spec.Target = t
 			res, err := install.PdbCreate(context.Background(), spec, reset)
 			if err != nil {
 				return err
@@ -143,11 +157,11 @@ step is deferred to a reverter follow-up plan.`,
     --db-unique-name ORCL`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// TODO(#519): wire license.RequireBundle("provision") once helper ships
-			if spec.Target == "" {
-				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
-					spec.Target = pt.Value.String()
-				}
+			t, err := resolveTarget(cmd, spec.Target)
+			if err != nil {
+				return err
 			}
+			spec.Target = t
 			res, err := install.DbcaCreateDb(context.Background(), spec, reset)
 			if err != nil {
 				return err
@@ -206,11 +220,11 @@ label-removal step is deferred to a reverter follow-up plan.`,
     --labels DATA1:/dev/sdb,DATA2:/dev/sdc`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// TODO(#519): wire license.RequireBundle("provision") once helper ships
-			if spec.Target == "" {
-				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
-					spec.Target = pt.Value.String()
-				}
+			t, err := resolveTarget(cmd, spec.Target)
+			if err != nil {
+				return err
 			}
+			spec.Target = t
 			if labelsFlag == "" {
 				return fmt.Errorf("--labels is required (comma-separated NAME:DEVICE pairs)")
 			}
@@ -283,11 +297,11 @@ deferred to a reverter follow-up plan.`,
     --listener-name LISTENER --port 1521`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// TODO(#519): wire license.RequireBundle("provision") once helper ships
-			if spec.Target == "" {
-				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
-					spec.Target = pt.Value.String()
-				}
+			t, err := resolveTarget(cmd, spec.Target)
+			if err != nil {
+				return err
 			}
+			spec.Target = t
 			res, err := install.NetcaSilent(context.Background(), spec, reset)
 			if err != nil {
 				return err
@@ -341,11 +355,11 @@ deferred to a reverter follow-up plan.`,
     --redundancy EXTERNAL --au-size-mb 4`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// TODO(#519): wire license.RequireBundle("provision") once helper ships
-			if spec.Target == "" {
-				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
-					spec.Target = pt.Value.String()
-				}
+			t, err := resolveTarget(cmd, spec.Target)
+			if err != nil {
+				return err
 			}
+			spec.Target = t
 			if disksFlag == "" {
 				return fmt.Errorf("--disks is required (comma-separated)")
 			}
@@ -387,13 +401,11 @@ func newInstallDbhomeCmd() *cobra.Command {
 		Short: "Run runInstaller -silent for Oracle DB Home 19c",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// TODO(#519): wire license.RequireBundle("provision") once helper ships
-			// spec.Target is bound directly via --target flag; inherit from parent
-			// persistent flag if not set on this leaf.
-			if spec.Target == "" {
-				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
-					spec.Target = pt.Value.String()
-				}
+			t, err := resolveTarget(cmd, spec.Target)
+			if err != nil {
+				return err
 			}
+			spec.Target = t
 			res, err := install.DBHomeInstall(context.Background(), spec, reset)
 			if err != nil {
 				return err
@@ -427,11 +439,11 @@ func newInstallRootshCmd() *cobra.Command {
 		Short: "Run <OracleHome>/root.sh idempotently after a runInstaller",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// TODO(#519): wire license.RequireBundle("provision") once helper ships
-			if spec.Target == "" {
-				if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
-					spec.Target = pt.Value.String()
-				}
+			t, err := resolveTarget(cmd, spec.Target)
+			if err != nil {
+				return err
 			}
+			spec.Target = t
 			res, err := install.RootSh(context.Background(), spec, reset)
 			if err != nil {
 				return err
@@ -474,15 +486,11 @@ Idempotency:
     --oracle-base /u01/app/grid \
     --response-file /tmp/grid.rsp`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Inherit --target from the provision parent persistent flag if
-			// not set directly on this leaf.
-			if spec.Target == "" {
-				if t, _ := cmd.Flags().GetString("target"); t != "" {
-					spec.Target = t
-				} else if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
-					spec.Target = pt.Value.String()
-				}
+			t, err := resolveTarget(cmd, spec.Target)
+			if err != nil {
+				return err
 			}
+			spec.Target = t
 			res, err := install.GridInstall(context.Background(), spec, reset)
 			if err != nil {
 				return err

--- a/cmd/dbxcli/root/provision_install.go
+++ b/cmd/dbxcli/root/provision_install.go
@@ -1,0 +1,81 @@
+package root
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/itunified-io/dbx/pkg/provision/install"
+	"github.com/spf13/cobra"
+)
+
+// NewInstallCmd returns the `provision install` parent subcommand.
+// Each leaf delegates to a function in dbx/pkg/provision/install/.
+//
+// License gate: provision domain maps to BundleOps
+// (pkg/core/license.DomainToBundle["provision"]). A RequireTier/RequireBundle
+// helper does not yet exist in pkg/core/license — tracked in #519.
+// When that helper ships, add:  license.RequireBundle(license.BundleOps)
+// at the top of each RunE.
+func NewInstallCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Oracle install primitives (grid, dbhome, root-sh, asmca, netca, asm-label)",
+	}
+	cmd.AddCommand(newInstallGridCmd())
+	return cmd
+}
+
+// newInstallGridCmd: dbxcli provision install grid --target X --oracle-home Y ...
+func newInstallGridCmd() *cobra.Command {
+	var (
+		spec  install.InstallSpec
+		reset bool
+	)
+	cmd := &cobra.Command{
+		Use:   "grid",
+		Short: "Run runInstaller -silent for Oracle Grid Infrastructure 19c",
+		Long: `Run Oracle Grid Infrastructure 19c runInstaller in silent mode.
+
+The caller (skill) is responsible for rendering and SCPing the response file
+to the target host before invoking this command.
+
+Idempotency:
+  - /etc/oraInst.loc + $GRID_HOME/inventory both present → skipped (Detected=installed)
+  - Only one present                                      → error (partial install)
+  - Neither present                                       → runs runInstaller`,
+		Example: `  dbxcli provision install grid --target ext3adm1 \
+    --oracle-home /u01/app/19c/grid \
+    --oracle-base /u01/app/grid \
+    --response-file /tmp/grid.rsp`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Inherit --target from the provision parent persistent flag if
+			// not set directly on this leaf.
+			if spec.Target == "" {
+				if t, _ := cmd.Flags().GetString("target"); t != "" {
+					spec.Target = t
+				} else if pt := cmd.InheritedFlags().Lookup("target"); pt != nil {
+					spec.Target = pt.Value.String()
+				}
+			}
+			res, err := install.GridInstall(context.Background(), spec, reset)
+			if err != nil {
+				return err
+			}
+			out, err := json.MarshalIndent(res, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&spec.Target, "target", "", "target name (overrides provision --target)")
+	cmd.Flags().StringVar(&spec.OracleHome, "oracle-home", "", "$GRID_HOME (e.g. /u01/app/19c/grid)")
+	cmd.Flags().StringVar(&spec.OracleBase, "oracle-base", "", "$ORACLE_BASE for grid (e.g. /u01/app/grid)")
+	cmd.Flags().StringVar(&spec.SoftwareStaging, "software-staging", "", "Path on host where Grid software is unzipped")
+	cmd.Flags().StringVar(&spec.ResponseFilePath, "response-file", "", "Absolute path on host to rendered .rsp file")
+	cmd.Flags().BoolVar(&reset, "reset", false, "Reset prior install state (NOT IMPLEMENTED YET — see #519 reverter follow-up)")
+	_ = cmd.MarkFlagRequired("oracle-home")
+	return cmd
+}

--- a/cmd/dbxcli/root/provision_install_e2e_test.go
+++ b/cmd/dbxcli/root/provision_install_e2e_test.go
@@ -1,0 +1,110 @@
+package root_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/itunified-io/dbx/cmd/dbxcli/root"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProvisionInstall_LeavesRegistered verifies all 8 install leaves
+// are wired under `dbxcli provision install`.
+func TestProvisionInstall_LeavesRegistered(t *testing.T) {
+	cmd := root.NewInstallCmd()
+	got := make(map[string]bool)
+	for _, c := range cmd.Commands() {
+		got[c.Name()] = true
+	}
+	for _, want := range []string{"grid", "dbhome", "root-sh", "asmca", "netca", "asm-label", "dbca", "pdb"} {
+		assert.True(t, got[want], "leaf %q not registered under `provision install`", want)
+	}
+}
+
+// TestProvisionInstall_LeafHelp ensures every leaf renders --help
+// without panic and surfaces its short description. This proves the
+// command tree builds, flags are wired, and required-flag markers do
+// not fire on --help (cobra's documented behavior).
+func TestProvisionInstall_LeafHelp(t *testing.T) {
+	leaves := []string{"grid", "dbhome", "root-sh", "asmca", "netca", "asm-label", "dbca", "pdb"}
+	for _, leaf := range leaves {
+		t.Run(leaf, func(t *testing.T) {
+			cmd := root.NewInstallCmd()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{leaf, "--help"})
+			err := cmd.Execute()
+			require.NoError(t, err, "leaf %s --help failed: %s", leaf, out.String())
+			assert.Contains(t, out.String(), leaf)
+		})
+	}
+}
+
+// TestProvisionInstall_MissingRequiredFlag verifies that each leaf
+// with a required flag list rejects an invocation that omits them.
+// This is a pure flag-parsing test — we never reach the install
+// primitive (which would attempt a real SSH connection).
+//
+// We pass a single required flag per leaf so that the missing-flag
+// error fires on a *different* required flag, proving the flag-required
+// chain works end-to-end without a live host.
+func TestProvisionInstall_MissingRequiredFlag(t *testing.T) {
+	cases := []struct {
+		leaf      string
+		args      []string
+		wantError string
+	}{
+		{leaf: "grid", args: []string{}, wantError: "oracle-home"},
+		{leaf: "dbhome", args: []string{}, wantError: "oracle-home"},
+		{leaf: "root-sh", args: []string{}, wantError: "oracle-home"},
+		{leaf: "asmca", args: []string{"--oracle-home", "/x"}, wantError: "oracle-base"},
+		{leaf: "netca", args: []string{"--oracle-home", "/x"}, wantError: "oracle-base"},
+		{leaf: "asm-label", args: []string{"--grid-home", "/x"}, wantError: "oracle-base"},
+		{leaf: "dbca", args: []string{"--oracle-home", "/x"}, wantError: "oracle-base"},
+		{leaf: "pdb", args: []string{"--oracle-home", "/x"}, wantError: "oracle-base"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.leaf, func(t *testing.T) {
+			cmd := root.NewInstallCmd()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			args := append([]string{tc.leaf}, tc.args...)
+			cmd.SetArgs(args)
+			err := cmd.Execute()
+			require.Error(t, err, "expected missing-required-flag error; out=%s", out.String())
+			combined := strings.ToLower(err.Error() + " " + out.String())
+			assert.Contains(t, combined, strings.ToLower(tc.wantError))
+		})
+	}
+}
+
+// TestProvisionInstall_TargetResolution verifies that --target on the
+// leaf is accepted. We deliberately pass it together with a list of
+// other required flags BUT omit at least one so cobra rejects with a
+// flag-validation error before any SSH attempt is made. The point is
+// to exercise resolveTarget()'s leaf-flag path without needing a live
+// host.
+func TestProvisionInstall_TargetResolution(t *testing.T) {
+	cmd := root.NewInstallCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	// grid only requires --oracle-home; pass --target + --oracle-home and
+	// exercise the leaf. Without a real host, install.GridInstall will
+	// fail at SSH; that's acceptable here — we only assert the command
+	// constructed and parsed flags. We add a sentinel check by NOT
+	// setting --target to verify resolveTarget surfaces its error.
+	cmd.SetArgs([]string{"grid", "--oracle-home", "/u01"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	combined := strings.ToLower(err.Error() + " " + out.String())
+	// Either the resolveTarget error, or the SSH attempt error if a
+	// stray default --target slipped in (defensive).
+	assert.True(t,
+		strings.Contains(combined, "target") || strings.Contains(combined, "ssh"),
+		"expected target-related error, got: %s", combined)
+}

--- a/cmd/dbxcli/root/provision_test.go
+++ b/cmd/dbxcli/root/provision_test.go
@@ -1,0 +1,36 @@
+package root_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/itunified-io/dbx/cmd/dbxcli/root"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvisionCmd_HelpShowsProvision(t *testing.T) {
+	cmd := root.NewProvisionCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+	// Help always returns nil (cobra calls os.Exit(0) on --help by default;
+	// we override that via SilenceUsage + DisableFlagParsing is not set, so
+	// we use RunE absence — cobra will call Help() and return nil).
+	err := cmd.Help()
+	require.NoError(t, err)
+	helpText := out.String()
+	assert.Contains(t, helpText, "provision")
+	// dbca + pdb subcommands added in Tasks 7 + 8; this test will
+	// gain assertions for them then.
+}
+
+func TestProvisionCmd_RegisteredOnRootCmd(t *testing.T) {
+	rootCmd := root.New("test")
+	names := make([]string, 0)
+	for _, c := range rootCmd.Commands() {
+		names = append(names, c.Name())
+	}
+	assert.Contains(t, names, "provision", "provision subcommand must be registered on root")
+}

--- a/cmd/dbxcli/root/root.go
+++ b/cmd/dbxcli/root/root.go
@@ -37,6 +37,7 @@ Commands use named parameters (emcli-style):
 	cmd.AddCommand(NewPolicyCmd())
 	cmd.AddCommand(NewRagCmd())
 	cmd.AddCommand(NewCloudCmd())
+	cmd.AddCommand(NewProvisionCmd())
 
 	return cmd
 }

--- a/pkg/host/executor.go
+++ b/pkg/host/executor.go
@@ -1,0 +1,19 @@
+// Package host defines the Executor interface used by install primitives
+// to run shell commands on remote hosts.
+package host
+
+import "context"
+
+// RunResult holds the outcome of a remote command.
+type RunResult struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}
+
+// Executor runs a shell command on a remote host and returns its output.
+// The concrete SSH implementation lives in pkg/host/sshexec; tests use
+// pkg/host/hosttest.MockExecutor.
+type Executor interface {
+	Run(ctx context.Context, command string) (*RunResult, error)
+}

--- a/pkg/host/hosttest/mock.go
+++ b/pkg/host/hosttest/mock.go
@@ -1,0 +1,128 @@
+// Package hosttest provides test helpers for the host.Executor interface.
+package hosttest
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/itunified-io/dbx/pkg/host"
+)
+
+// mockEntry is a single registered command expectation.
+type mockEntry struct {
+	exact   string         // exact command match (if non-empty)
+	pattern *regexp.Regexp // regexp match (if non-nil)
+	result  *host.RunResult
+}
+
+// MockExecutor implements host.Executor for unit tests. Register
+// expectations with OnCommand or OnCommandPattern before calling
+// gridInstallWithExec (or any function under test).
+//
+// Unregistered commands return an error; this surfaces unexpected calls
+// immediately rather than silently returning zero values.
+//
+// MockExecutor is safe for concurrent use from multiple goroutines.
+type MockExecutor struct {
+	mu      sync.Mutex
+	entries []mockEntry
+	calls   []string // recorded in invocation order
+}
+
+// NewMockExecutor returns an empty MockExecutor.
+func NewMockExecutor() *MockExecutor {
+	return &MockExecutor{}
+}
+
+// stub is a builder used by OnCommand / OnCommandPattern to attach a Returns call.
+type stub struct {
+	m   *MockExecutor
+	idx int
+}
+
+// Returns registers the exit code, stdout, and stderr for the stub.
+func (s *stub) Returns(exitCode int, stdout, stderr string) {
+	s.m.mu.Lock()
+	defer s.m.mu.Unlock()
+	s.m.entries[s.idx].result = &host.RunResult{
+		ExitCode: exitCode,
+		Stdout:   stdout,
+		Stderr:   stderr,
+	}
+}
+
+// OnCommand registers an exact-match expectation. The first matching entry wins.
+func (m *MockExecutor) OnCommand(exact string) *stub {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries = append(m.entries, mockEntry{exact: exact})
+	return &stub{m: m, idx: len(m.entries) - 1}
+}
+
+// OnCommandPattern registers a regexp-match expectation.
+func (m *MockExecutor) OnCommandPattern(pattern string) *stub {
+	re := regexp.MustCompile(pattern)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries = append(m.entries, mockEntry{pattern: re})
+	return &stub{m: m, idx: len(m.entries) - 1}
+}
+
+// Run satisfies host.Executor. It records the command and returns the result
+// of the first matching entry, or an error if no entry matches.
+func (m *MockExecutor) Run(_ context.Context, command string) (*host.RunResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, command)
+	for _, e := range m.entries {
+		if e.exact != "" && e.exact == command {
+			return e.result, nil
+		}
+		if e.pattern != nil && e.pattern.MatchString(command) {
+			return e.result, nil
+		}
+	}
+	return nil, fmt.Errorf("hosttest: unexpected command: %q", command)
+}
+
+// Calls returns a copy of the recorded command history (in invocation order).
+// Safe to call concurrently with Run().
+func (m *MockExecutor) Calls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.calls))
+	copy(out, m.calls)
+	return out
+}
+
+// AssertCalled fails the test if cmd was NOT among recorded calls.
+// Substring match (uses strings.Contains) so callers can assert on a
+// fragment of a longer composed command.
+func (m *MockExecutor) AssertCalled(t testing.TB, cmd string) {
+	t.Helper()
+	for _, c := range m.Calls() {
+		if strings.Contains(c, cmd) {
+			return
+		}
+	}
+	t.Fatalf("expected command containing %q, got %d calls: %v", cmd, len(m.Calls()), m.Calls())
+}
+
+// AssertCallCount fails the test if the number of calls containing cmd
+// (substring match) is not exactly n.
+func (m *MockExecutor) AssertCallCount(t testing.TB, cmd string, n int) {
+	t.Helper()
+	count := 0
+	for _, c := range m.Calls() {
+		if strings.Contains(c, cmd) {
+			count++
+		}
+	}
+	if count != n {
+		t.Fatalf("expected %d calls containing %q, got %d: %v", n, cmd, count, m.Calls())
+	}
+}

--- a/pkg/host/hosttest/mock_test.go
+++ b/pkg/host/hosttest/mock_test.go
@@ -1,0 +1,80 @@
+package hosttest
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeT is a minimal testing.TB stub that captures failure without calling
+// runtime.Goexit (which panics when used outside of a real tRunner goroutine).
+type fakeT struct {
+	testing.TB
+	failed bool
+}
+
+func (f *fakeT) Helper()                           {}
+func (f *fakeT) Fatalf(_ string, _ ...interface{}) { f.failed = true }
+
+func TestMockExecutor_RecordsCalls(t *testing.T) {
+	m := NewMockExecutor()
+	m.OnCommand("foo").Returns(0, "ok", "")
+	m.OnCommand("bar").Returns(0, "ok", "")
+
+	_, _ = m.Run(context.Background(), "foo")
+	_, _ = m.Run(context.Background(), "bar")
+
+	assert.Equal(t, []string{"foo", "bar"}, m.Calls())
+	m.AssertCalled(t, "foo")
+	m.AssertCallCount(t, "foo", 1)
+	m.AssertCallCount(t, "bar", 1)
+	m.AssertCallCount(t, "missing", 0)
+}
+
+func TestMockExecutor_AssertCalled_FailsOnAbsent(t *testing.T) {
+	m := NewMockExecutor()
+	m.OnCommand("foo").Returns(0, "", "")
+	_, _ = m.Run(context.Background(), "foo")
+
+	ft := &fakeT{}
+	m.AssertCalled(ft, "missing")
+	assert.True(t, ft.failed, "AssertCalled should fail when cmd absent")
+}
+
+func TestMockExecutor_ParallelSafe(t *testing.T) {
+	m := NewMockExecutor()
+	m.OnCommandPattern(`.*`).Returns(0, "ok", "")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = m.Run(context.Background(), "concurrent")
+		}()
+	}
+	wg.Wait()
+	require.Len(t, m.Calls(), 50)
+}
+
+func TestMockExecutor_OnCommandPattern_Matches(t *testing.T) {
+	m := NewMockExecutor()
+	m.OnCommandPattern(`runInstaller .*-silent`).Returns(0, "Installation Successful.", "")
+
+	res, err := m.Run(context.Background(), "/u01/app/19c/grid/runInstaller -silent -responseFile /tmp/grid.rsp")
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.ExitCode)
+	assert.Contains(t, res.Stdout, "Successful")
+}
+
+func TestMockExecutor_UnmatchedCommand_ReturnsError(t *testing.T) {
+	m := NewMockExecutor()
+	m.OnCommand("expected").Returns(0, "", "")
+
+	_, err := m.Run(context.Background(), "unexpected")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected")
+}

--- a/pkg/otel/global.go
+++ b/pkg/otel/global.go
@@ -1,0 +1,35 @@
+package otel
+
+import "sync"
+
+// globalExporter is the package-level Exporter used by emitters that
+// don't carry an Exporter explicitly through their call graph (the 8
+// install primitives in pkg/provision/install are the first consumers).
+//
+// Defaults to NoopExporter so callers always have a valid sink without
+// any wiring; production code calls SetGlobalExporter from main() to
+// install an OTLPExporter (or similar).
+var (
+	globalExporter Exporter = NoopExporter{}
+	globalMu       sync.RWMutex
+)
+
+// GlobalExporter returns the currently registered Exporter. Always
+// non-nil (NoopExporter when no explicit exporter is set).
+func GlobalExporter() Exporter {
+	globalMu.RLock()
+	defer globalMu.RUnlock()
+	return globalExporter
+}
+
+// SetGlobalExporter installs e as the package-level Exporter. Passing
+// nil resets to NoopExporter so callers can never end up with a nil
+// exporter at Export() time.
+func SetGlobalExporter(e Exporter) {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	if e == nil {
+		e = NoopExporter{}
+	}
+	globalExporter = e
+}

--- a/pkg/provision/install/asm_label.go
+++ b/pkg/provision/install/asm_label.go
@@ -1,0 +1,289 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/itunified-io/dbx/pkg/host"
+)
+
+// asmLabelSentinelDir is the directory under OracleBase where dbx writes
+// the per-label two-phase sentinel files. Per package godoc, this is the
+// canonical location for non-idempotent install primitives.
+const asmLabelSentinelDir = "/cfgtoollogs/dbx"
+
+// oracleasmBin is the absolute path to the ASMlib admin tool. Stock
+// oracleasm-support packages install it under /usr/sbin and non-
+// interactive SSH sessions do NOT have /usr/sbin on $PATH for unprivileged
+// users — qualifying with the absolute path mirrors the lsnrctl fix made
+// to NetcaSilent (do not repeat the bare-command bug).
+const oracleasmBin = "/usr/sbin/oracleasm"
+
+// AsmDiskLabel labels raw block devices via ASMlib (oracleasm) or the
+// Oracle ASM Filter Driver (AFD) so the disks become discoverable as ASM
+// disks. This is a Phase D.1 prerequisite that runs BEFORE
+// AsmcaSilent (which creates the diskgroup over labeled devices).
+//
+// Idempotency: NON-IDEMPOTENT primitive — uses the per-label two-phase
+// sentinel pattern documented in the install package godoc. Each label
+// gets its own .partial / .installed sentinel pair keyed on the label
+// name (uppercased) so multiple disks on the same host don't collide.
+// Detection is version-agnostic: file existence + a live oracleasm
+// listdisks / asmcmd afd_lslbl probe; no version-string match.
+//
+// Reset semantics (MVP): --reset on Installed/Partial state for any
+// label prints a manual recovery runbook to stderr for that label and
+// records it as Skipped in the result. Destructive label removal is
+// deferred to a reverter follow-up plan; this primitive does NOT delete
+// labels.
+//
+// Per-label failure semantics: if a label fails to create (non-zero
+// exit, transport failure, ctx-cancel), the function returns the
+// partial AsmDiskLabelResult plus an error AND stops processing
+// subsequent labels. The .partial sentinel for the failing label
+// persists so a re-run sees Partial and the operator must run the
+// matching reverter before retrying that label.
+func AsmDiskLabel(ctx context.Context, spec AsmDiskLabelSpec, reset bool) (*AsmDiskLabelResult, error) {
+	exec, err := newSSHExecutor(ctx, spec.Target)
+	if err != nil {
+		return nil, fmt.Errorf("install: ssh to %s: %w", spec.Target, err)
+	}
+	return asmDiskLabelWithExec(ctx, exec, spec, reset)
+}
+
+// asmDiskLabelWithExec is the testable core. Takes an injected executor
+// so unit tests can use hosttest.MockExecutor.
+func asmDiskLabelWithExec(ctx context.Context, exec host.Executor, spec AsmDiskLabelSpec, reset bool) (*AsmDiskLabelResult, error) {
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+
+	res := &AsmDiskLabelResult{Implementation: spec.Implementation}
+
+	for _, lbl := range spec.Labels {
+		partialPath, installedPath := asmLabelSentinelPaths(spec, lbl)
+		lr := AsmDiskLabelLabelResult{Name: lbl.Name, Device: lbl.Device}
+
+		state, err := detectAsmDiskLabelState(ctx, exec, spec.Implementation, spec.GridHome, lbl, partialPath, installedPath)
+		if err != nil {
+			lr.Detected = DetectionStateAbsent
+			res.Labels = append(res.Labels, lr)
+			return res, fmt.Errorf("install: detect %s label %s on %s: %w", spec.Implementation, lbl.Name, spec.Target, err)
+		}
+		lr.Detected = state
+
+		switch state {
+		case DetectionStateInstalled:
+			if !reset {
+				lr.Skipped = true
+				res.Labels = append(res.Labels, lr)
+				continue
+			}
+			fmt.Fprint(os.Stderr, asmLabelResetRunbook(spec, lbl, "installed", installedPath))
+			lr.Skipped = true
+			res.Labels = append(res.Labels, lr)
+			continue
+		case DetectionStatePartial:
+			if !reset {
+				res.Labels = append(res.Labels, lr)
+				return res, fmt.Errorf("install: partial asm-label state on %s for %s (sentinel %s present without %s); rerun with --reset to print recovery runbook", spec.Target, lbl.Name, partialPath, installedPath)
+			}
+			fmt.Fprint(os.Stderr, asmLabelResetRunbook(spec, lbl, "partial", partialPath))
+			lr.Skipped = true
+			res.Labels = append(res.Labels, lr)
+			continue
+		case DetectionStateAbsent:
+			// fall through
+		}
+
+		// Phase 1: write .partial sentinel BEFORE invoking the labeler.
+		mkdirCmd := fmt.Sprintf("mkdir -p %s && : > %s",
+			shellEscape(asmLabelSentinelRoot(spec)),
+			shellEscape(partialPath),
+		)
+		if _, err := exec.Run(ctx, mkdirCmd); err != nil {
+			if ctx.Err() != nil {
+				lr.Detected = DetectionStatePartial
+				res.Labels = append(res.Labels, lr)
+				return res, fmt.Errorf("install: asm-label sentinel-write interrupted (ctx %v); remote process may still be running on %s for %s: %w", ctx.Err(), spec.Target, lbl.Name, err)
+			}
+			res.Labels = append(res.Labels, lr)
+			return res, fmt.Errorf("install: write asm-label .partial sentinel for %s on %s: %w", lbl.Name, spec.Target, err)
+		}
+
+		// Phase 2: invoke the labeler.
+		cmd := asmLabelCreateCmd(spec, lbl)
+		runRes, err := exec.Run(ctx, cmd)
+		if err != nil {
+			// Local context cancelled mid-run: remote process may still be
+			// running. .partial sentinel persists so next probe sees Partial.
+			if ctx.Err() != nil {
+				lr.Detected = DetectionStatePartial
+				res.Labels = append(res.Labels, lr)
+				return res, fmt.Errorf("install: asm-label %s interrupted (ctx %v); remote process may still be running on %s; next run will see partial state: %w", lbl.Name, ctx.Err(), spec.Target, err)
+			}
+			res.Labels = append(res.Labels, lr)
+			return res, fmt.Errorf("install: asm-label transport failure on %s for %s: %w", spec.Target, lbl.Name, err)
+		}
+		lr.ExitCode = runRes.ExitCode
+		lr.LogTail = tailLog(runRes.Stdout+runRes.Stderr, 50)
+		if runRes.ExitCode != 0 {
+			// Non-zero exit: leave .partial in place so operator runs reverter.
+			lr.Detected = DetectionStatePartial
+			res.Labels = append(res.Labels, lr)
+			return res, fmt.Errorf("install: asm-label %s exit %d on %s", lbl.Name, runRes.ExitCode, spec.Target)
+		}
+
+		// Phase 3: atomic rename .partial → .installed.
+		mvCmd := fmt.Sprintf("mv %s %s", shellEscape(partialPath), shellEscape(installedPath))
+		if _, err := exec.Run(ctx, mvCmd); err != nil {
+			if ctx.Err() != nil {
+				lr.Detected = DetectionStatePartial
+				res.Labels = append(res.Labels, lr)
+				return res, fmt.Errorf("install: asm-label sentinel-rename interrupted (ctx %v) on %s for %s: %w", ctx.Err(), spec.Target, lbl.Name, err)
+			}
+			res.Labels = append(res.Labels, lr)
+			return res, fmt.Errorf("install: rename asm-label sentinel for %s on %s: %w", lbl.Name, spec.Target, err)
+		}
+		lr.Detected = DetectionStateInstalled
+		res.Labels = append(res.Labels, lr)
+	}
+	return res, nil
+}
+
+// asmLabelCreateCmd builds the per-impl create command. Both forms use
+// absolute binary paths to defend against $PATH-less non-interactive SSH
+// sessions; AFD additionally wraps with `env ORACLE_HOME=<grid_home>`
+// because asmcmd reads ORACLE_HOME at startup.
+func asmLabelCreateCmd(spec AsmDiskLabelSpec, lbl AsmLabelEntry) string {
+	switch spec.Implementation {
+	case AsmDiskLabelImplAsmlib:
+		return fmt.Sprintf("%s createdisk %s %s",
+			oracleasmBin,
+			shellEscape(lbl.Name),
+			shellEscape(lbl.Device),
+		)
+	case AsmDiskLabelImplAFD:
+		return fmt.Sprintf("env ORACLE_HOME=%s %s/bin/asmcmd afd_label %s %s --init",
+			shellEscape(spec.GridHome),
+			shellEscape(spec.GridHome),
+			shellEscape(lbl.Name),
+			shellEscape(lbl.Device),
+		)
+	}
+	// Validate guarantees this is unreachable; return a clearly-broken
+	// command so any regression surfaces as a test failure rather than
+	// silent skip.
+	return fmt.Sprintf("false # install: unknown impl %q", spec.Implementation)
+}
+
+// detectAsmDiskLabelState reads the per-label two-phase sentinel pair
+// PLUS a live oracleasm/afd_lslbl probe. The live probe handles labels
+// that exist from a prior run that did not record a dbx sentinel.
+//
+//	.installed sentinel present              → Installed
+//	live probe matches label                 → Installed
+//	.partial present without .installed      → Partial
+//	none of the above                        → Absent
+//
+// The live probe is version-agnostic — it only checks exit code +
+// label-name presence in stdout, never matching a version string.
+func detectAsmDiskLabelState(ctx context.Context, exec host.Executor, impl, gridHome string, lbl AsmLabelEntry, partialPath, installedPath string) (DetectionState, error) {
+	hasInstalled, err := probeFile(ctx, exec, installedPath)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if hasInstalled {
+		return DetectionStateInstalled, nil
+	}
+	// Live probe.
+	probeCmd := asmLabelProbeCmd(impl, gridHome, lbl)
+	live, err := exec.Run(ctx, probeCmd)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if live.ExitCode == 0 && strings.Contains(live.Stdout, lbl.Name) {
+		return DetectionStateInstalled, nil
+	}
+	hasPartial, err := probeFile(ctx, exec, partialPath)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if hasPartial {
+		return DetectionStatePartial, nil
+	}
+	return DetectionStateAbsent, nil
+}
+
+// asmLabelProbeCmd builds the per-impl live probe. ASMlib uses
+// `oracleasm listdisks` (lists all configured labels, one per line);
+// AFD uses `asmcmd afd_lslbl <device>` which prints the label keyed
+// to a specific device path. Both wrap exec invocations in absolute
+// paths for the same $PATH reasons as the create command.
+func asmLabelProbeCmd(impl, gridHome string, lbl AsmLabelEntry) string {
+	switch impl {
+	case AsmDiskLabelImplAsmlib:
+		return fmt.Sprintf("%s listdisks", oracleasmBin)
+	case AsmDiskLabelImplAFD:
+		return fmt.Sprintf("env ORACLE_HOME=%s %s/bin/asmcmd afd_lslbl %s",
+			shellEscape(gridHome),
+			shellEscape(gridHome),
+			shellEscape(lbl.Device),
+		)
+	}
+	return "false"
+}
+
+// asmLabelSentinelRoot returns the directory under OracleBase that holds
+// dbx sentinel files for this primitive.
+func asmLabelSentinelRoot(spec AsmDiskLabelSpec) string {
+	return spec.OracleBase + asmLabelSentinelDir
+}
+
+// asmLabelSentinelPaths returns (partialPath, installedPath) keyed on
+// the label name (uppercased) so multiple labels on the same host
+// don't collide.
+func asmLabelSentinelPaths(spec AsmDiskLabelSpec, lbl AsmLabelEntry) (string, string) {
+	root := asmLabelSentinelRoot(spec)
+	name := strings.ToUpper(lbl.Name)
+	return root + "/asm-label." + name + ".partial",
+		root + "/asm-label." + name + ".installed"
+}
+
+// asmLabelResetRunbook returns a manual recovery runbook string that the
+// caller prints to stderr when --reset is invoked. The MVP does NOT
+// remove the label; the operator must do that themselves.
+func asmLabelResetRunbook(spec AsmDiskLabelSpec, lbl AsmLabelEntry, state, sentinelPath string) string {
+	var unlabel string
+	switch spec.Implementation {
+	case AsmDiskLabelImplAsmlib:
+		unlabel = fmt.Sprintf("%s deletedisk %s", oracleasmBin, lbl.Name)
+	case AsmDiskLabelImplAFD:
+		unlabel = fmt.Sprintf("env ORACLE_HOME=%s %s/bin/asmcmd afd_unlabel %s",
+			spec.GridHome, spec.GridHome, lbl.Name)
+	}
+	return fmt.Sprintf(`# asm-label --reset (MANUAL RUNBOOK; non-destructive in MVP)
+#
+# State on %s: %s
+# Sentinel:   %s
+# Label:      %s  (impl=%s, device=%s)
+#
+# This primitive will NOT remove the label automatically.
+# Manual recovery procedure:
+#
+#   1. Confirm no diskgroup currently uses %s:
+#        sqlplus -s / as sysasm <<<'select group_number, name from v$asm_disk where label='"'"'%s'"'"';'
+#
+#   2. (Operator) remove the label:
+#        %s
+#
+#   3. Remove the dbx sentinel:
+#        rm -f %s
+#
+#   4. Re-run dbxcli provision install asm-label (without --reset).
+#
+`, spec.Target, state, sentinelPath, lbl.Name, spec.Implementation, lbl.Device,
+		lbl.Name, lbl.Name, unlabel, sentinelPath)
+}

--- a/pkg/provision/install/asm_label.go
+++ b/pkg/provision/install/asm_label.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/otel"
 )
 
 // asmLabelSentinelDir is the directory under OracleBase where dbx writes
@@ -55,12 +56,20 @@ func AsmDiskLabel(ctx context.Context, spec AsmDiskLabelSpec, reset bool) (*AsmD
 
 // asmDiskLabelWithExec is the testable core. Takes an injected executor
 // so unit tests can use hosttest.MockExecutor.
-func asmDiskLabelWithExec(ctx context.Context, exec host.Executor, spec AsmDiskLabelSpec, reset bool) (*AsmDiskLabelResult, error) {
+func asmDiskLabelWithExec(ctx context.Context, exec host.Executor, spec AsmDiskLabelSpec, reset bool) (res *AsmDiskLabelResult, retErr error) {
+	sb := otel.NewSpan("provision.install.asm_label", "dbxcli").
+		WithAttrs(
+			otel.StringAttr(otel.AttrDbxHost, spec.Target),
+			otel.StringAttr(otel.AttrDbxEntityType, "asm_disk_labels"),
+			otel.StringAttr(otel.AttrDbxEntityName, spec.Implementation),
+		)
+	defer func() { emitSpan(ctx, sb, retErr) }()
+
 	if err := spec.Validate(); err != nil {
 		return nil, err
 	}
 
-	res := &AsmDiskLabelResult{Implementation: spec.Implementation}
+	res = &AsmDiskLabelResult{Implementation: spec.Implementation}
 
 	for _, lbl := range spec.Labels {
 		partialPath, installedPath := asmLabelSentinelPaths(spec, lbl)

--- a/pkg/provision/install/asm_label.go
+++ b/pkg/provision/install/asm_label.go
@@ -259,10 +259,10 @@ func asmLabelResetRunbook(spec AsmDiskLabelSpec, lbl AsmLabelEntry, state, senti
 	var unlabel string
 	switch spec.Implementation {
 	case AsmDiskLabelImplAsmlib:
-		unlabel = fmt.Sprintf("%s deletedisk %s", oracleasmBin, lbl.Name)
+		unlabel = fmt.Sprintf("%s deletedisk %s", oracleasmBin, shellEscape(lbl.Name))
 	case AsmDiskLabelImplAFD:
 		unlabel = fmt.Sprintf("env ORACLE_HOME=%s %s/bin/asmcmd afd_unlabel %s",
-			spec.GridHome, spec.GridHome, lbl.Name)
+			shellEscape(spec.GridHome), shellEscape(spec.GridHome), shellEscape(lbl.Name))
 	}
 	return fmt.Sprintf(`# asm-label --reset (MANUAL RUNBOOK; non-destructive in MVP)
 #

--- a/pkg/provision/install/asm_label_test.go
+++ b/pkg/provision/install/asm_label_test.go
@@ -1,0 +1,385 @@
+package install
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/host/hosttest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validAsmlibSpec returns a minimal valid ASMlib spec usable across tests.
+func validAsmlibSpec() AsmDiskLabelSpec {
+	return AsmDiskLabelSpec{
+		Target:         "ext3adm1",
+		GridHome:       "/u01/app/19c/grid",
+		OracleBase:     "/u01/app/grid",
+		Implementation: AsmDiskLabelImplAsmlib,
+		Labels: []AsmLabelEntry{
+			{Name: "DATA1", Device: "/dev/sdb"},
+		},
+	}
+}
+
+// validAFDSpec returns a minimal valid AFD spec usable across tests.
+func validAFDSpec() AsmDiskLabelSpec {
+	return AsmDiskLabelSpec{
+		Target:         "ext3adm1",
+		GridHome:       "/u01/app/19c/grid",
+		OracleBase:     "/u01/app/grid",
+		Implementation: AsmDiskLabelImplAFD,
+		Labels: []AsmLabelEntry{
+			{Name: "DATA1", Device: "/dev/sdb"},
+		},
+	}
+}
+
+func TestAsmDiskLabel(t *testing.T) {
+	const installedAsmlib = "/u01/app/grid/cfgtoollogs/dbx/asm-label.DATA1.installed"
+	const partialAsmlib = "/u01/app/grid/cfgtoollogs/dbx/asm-label.DATA1.partial"
+	const probeAsmlib = "/usr/sbin/oracleasm listdisks"
+	const mkdirAsmlib = "mkdir -p /u01/app/grid/cfgtoollogs/dbx && : > /u01/app/grid/cfgtoollogs/dbx/asm-label.DATA1.partial"
+	const createAsmlib = "/usr/sbin/oracleasm createdisk DATA1 /dev/sdb"
+	const mvAsmlib = "mv /u01/app/grid/cfgtoollogs/dbx/asm-label.DATA1.partial /u01/app/grid/cfgtoollogs/dbx/asm-label.DATA1.installed"
+
+	const probeAFD = "env ORACLE_HOME=/u01/app/19c/grid /u01/app/19c/grid/bin/asmcmd afd_lslbl /dev/sdb"
+	const createAFD = "env ORACLE_HOME=/u01/app/19c/grid /u01/app/19c/grid/bin/asmcmd afd_label DATA1 /dev/sdb --init"
+
+	cases := []struct {
+		name            string
+		setupMock       func(*hosttest.MockExecutor)
+		spec            AsmDiskLabelSpec
+		reset           bool
+		wantErr         string
+		wantSkipped     bool   // for first label
+		wantDetected    DetectionState // for first label
+		wantLogContains string
+	}{
+		{
+			name: "Asmlib_InstalledSentinel_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installedAsmlib).Returns(0, "", "")
+			},
+			spec:         validAsmlibSpec(),
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "Asmlib_LiveProbeMatches_NoSentinel_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installedAsmlib).Returns(1, "", "")
+				m.OnCommand(probeAsmlib).Returns(0, "DATA1\nDATA2\n", "")
+			},
+			spec:         validAsmlibSpec(),
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "Asmlib_PartialSentinel_ReturnsError",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installedAsmlib).Returns(1, "", "")
+				m.OnCommand(probeAsmlib).Returns(0, "OTHER\n", "")
+				m.OnCommand("test -f " + partialAsmlib).Returns(0, "", "")
+			},
+			spec:         validAsmlibSpec(),
+			wantErr:      "partial asm-label state",
+			wantDetected: DetectionStatePartial,
+		},
+		{
+			name: "Asmlib_Absent_RunsFullPipeline",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installedAsmlib).Returns(1, "", "")
+				m.OnCommand(probeAsmlib).Returns(0, "OTHER\n", "")
+				m.OnCommand("test -f " + partialAsmlib).Returns(1, "", "")
+				m.OnCommand(mkdirAsmlib).Returns(0, "", "")
+				m.OnCommand(createAsmlib).Returns(0, "Writing disk header: done\nInstantiating disk: done\n", "")
+				m.OnCommand(mvAsmlib).Returns(0, "", "")
+			},
+			spec:            validAsmlibSpec(),
+			wantSkipped:     false,
+			wantDetected:    DetectionStateInstalled,
+			wantLogContains: "Writing disk header",
+		},
+		{
+			name: "Asmlib_CreateExitNonzero_LeavesPartialAndErrors",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installedAsmlib).Returns(1, "", "")
+				m.OnCommand(probeAsmlib).Returns(0, "OTHER\n", "")
+				m.OnCommand("test -f " + partialAsmlib).Returns(1, "", "")
+				m.OnCommand(mkdirAsmlib).Returns(0, "", "")
+				m.OnCommand(createAsmlib).Returns(1, "ERROR: device not found\n", "")
+			},
+			spec:            validAsmlibSpec(),
+			wantErr:         "exit 1",
+			wantDetected:    DetectionStatePartial,
+			wantLogContains: "device not found",
+		},
+		{
+			name: "Asmlib_Reset_OnInstalled_PrintsRunbook_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installedAsmlib).Returns(0, "", "")
+			},
+			spec:         validAsmlibSpec(),
+			reset:        true,
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "Asmlib_Reset_OnPartial_PrintsRunbook_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installedAsmlib).Returns(1, "", "")
+				m.OnCommand(probeAsmlib).Returns(0, "OTHER\n", "")
+				m.OnCommand("test -f " + partialAsmlib).Returns(0, "", "")
+			},
+			spec:         validAsmlibSpec(),
+			reset:        true,
+			wantSkipped:  true,
+			wantDetected: DetectionStatePartial,
+		},
+		{
+			name: "AFD_InstalledSentinel_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installedAsmlib).Returns(0, "", "")
+			},
+			spec:         validAFDSpec(),
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "AFD_LiveProbeMatches_NoSentinel_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installedAsmlib).Returns(1, "", "")
+				m.OnCommand(probeAFD).Returns(0, "--------------------------------------------------------------------------------\nLabel                     Duplicate  Path\n================================================================================\nDATA1                                /dev/sdb\n", "")
+			},
+			spec:         validAFDSpec(),
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "AFD_Absent_RunsFullPipeline",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installedAsmlib).Returns(1, "", "")
+				m.OnCommand(probeAFD).Returns(0, "Label                     Duplicate  Path\n", "")
+				m.OnCommand("test -f " + partialAsmlib).Returns(1, "", "")
+				m.OnCommand(mkdirAsmlib).Returns(0, "", "")
+				m.OnCommand(createAFD).Returns(0, "Disk DATA1 successfully labeled.\n", "")
+				m.OnCommand(mvAsmlib).Returns(0, "", "")
+			},
+			spec:            validAFDSpec(),
+			wantSkipped:     false,
+			wantDetected:    DetectionStateInstalled,
+			wantLogContains: "successfully labeled",
+		},
+		{
+			name:         "RejectsMissingTarget",
+			setupMock:    func(m *hosttest.MockExecutor) {},
+			spec:         AsmDiskLabelSpec{GridHome: "/x", OracleBase: "/y", Implementation: AsmDiskLabelImplAsmlib, Labels: []AsmLabelEntry{{Name: "X", Device: "/dev/sdb"}}},
+			wantErr:      "target is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:         "RejectsMissingGridHome",
+			setupMock:    func(m *hosttest.MockExecutor) {},
+			spec:         AsmDiskLabelSpec{Target: "x", OracleBase: "/y", Implementation: AsmDiskLabelImplAsmlib, Labels: []AsmLabelEntry{{Name: "X", Device: "/dev/sdb"}}},
+			wantErr:      "grid_home is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:         "RejectsMissingOracleBase",
+			setupMock:    func(m *hosttest.MockExecutor) {},
+			spec:         AsmDiskLabelSpec{Target: "x", GridHome: "/y", Implementation: AsmDiskLabelImplAsmlib, Labels: []AsmLabelEntry{{Name: "X", Device: "/dev/sdb"}}},
+			wantErr:      "oracle_base is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:         "RejectsInvalidImpl",
+			setupMock:    func(m *hosttest.MockExecutor) {},
+			spec:         AsmDiskLabelSpec{Target: "x", GridHome: "/y", OracleBase: "/z", Implementation: "udev", Labels: []AsmLabelEntry{{Name: "X", Device: "/dev/sdb"}}},
+			wantErr:      "implementation must be",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:         "RejectsEmptyLabels",
+			setupMock:    func(m *hosttest.MockExecutor) {},
+			spec:         AsmDiskLabelSpec{Target: "x", GridHome: "/y", OracleBase: "/z", Implementation: AsmDiskLabelImplAsmlib},
+			wantErr:      "labels list is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsLabelNameWithSemicolon",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmDiskLabelSpec{
+				Target: "x", GridHome: "/y", OracleBase: "/z", Implementation: AsmDiskLabelImplAsmlib,
+				Labels: []AsmLabelEntry{{Name: "DATA1;rm -rf /", Device: "/dev/sdb"}},
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsLabelNameWithBacktick",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmDiskLabelSpec{
+				Target: "x", GridHome: "/y", OracleBase: "/z", Implementation: AsmDiskLabelImplAsmlib,
+				Labels: []AsmLabelEntry{{Name: "D`whoami`", Device: "/dev/sdb"}},
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsDeviceWithDollar",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmDiskLabelSpec{
+				Target: "x", GridHome: "/y", OracleBase: "/z", Implementation: AsmDiskLabelImplAsmlib,
+				Labels: []AsmLabelEntry{{Name: "DATA1", Device: "/dev/$(id)"}},
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsTargetWithNewline",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmDiskLabelSpec{
+				Target: "x\nrm -rf /", GridHome: "/y", OracleBase: "/z", Implementation: AsmDiskLabelImplAsmlib,
+				Labels: []AsmLabelEntry{{Name: "DATA1", Device: "/dev/sdb"}},
+			},
+			wantErr:      "control character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsDuplicateLabelNames",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmDiskLabelSpec{
+				Target: "x", GridHome: "/y", OracleBase: "/z", Implementation: AsmDiskLabelImplAsmlib,
+				Labels: []AsmLabelEntry{
+					{Name: "DATA1", Device: "/dev/sdb"},
+					{Name: "DATA1", Device: "/dev/sdc"},
+				},
+			},
+			wantErr:      "duplicated",
+			wantDetected: DetectionStateUnset,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := hosttest.NewMockExecutor()
+			tc.setupMock(mock)
+			res, err := asmDiskLabelWithExec(context.Background(), mock, tc.spec, tc.reset)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				if tc.wantLogContains != "" && res != nil && len(res.Labels) > 0 {
+					assert.Contains(t, res.Labels[0].LogTail, tc.wantLogContains)
+				}
+				if tc.wantDetected != DetectionStateUnset && res != nil && len(res.Labels) > 0 {
+					assert.Equal(t, tc.wantDetected, res.Labels[0].Detected)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.Len(t, res.Labels, 1)
+			assert.Equal(t, tc.wantSkipped, res.Labels[0].Skipped)
+			assert.Equal(t, tc.wantDetected, res.Labels[0].Detected)
+			if tc.wantLogContains != "" {
+				assert.Contains(t, res.Labels[0].LogTail, tc.wantLogContains)
+			}
+		})
+	}
+}
+
+// TestAsmDiskLabel_MultipleLabels_AllProcessed exercises the label loop
+// to confirm a mix of skip + create works in a single invocation.
+func TestAsmDiskLabel_MultipleLabels_AllProcessed(t *testing.T) {
+	const installedData1 = "/u01/app/grid/cfgtoollogs/dbx/asm-label.DATA1.installed"
+	const installedData2 = "/u01/app/grid/cfgtoollogs/dbx/asm-label.DATA2.installed"
+	const partialData2 = "/u01/app/grid/cfgtoollogs/dbx/asm-label.DATA2.partial"
+	const probe = "/usr/sbin/oracleasm listdisks"
+	const mkdir2 = "mkdir -p /u01/app/grid/cfgtoollogs/dbx && : > /u01/app/grid/cfgtoollogs/dbx/asm-label.DATA2.partial"
+	const create2 = "/usr/sbin/oracleasm createdisk DATA2 /dev/sdc"
+	const mv2 = "mv /u01/app/grid/cfgtoollogs/dbx/asm-label.DATA2.partial /u01/app/grid/cfgtoollogs/dbx/asm-label.DATA2.installed"
+
+	mock := hosttest.NewMockExecutor()
+	// DATA1: installed sentinel present → skip.
+	mock.OnCommand("test -f " + installedData1).Returns(0, "", "")
+	// DATA2: absent → run full pipeline.
+	mock.OnCommand("test -f " + installedData2).Returns(1, "", "")
+	mock.OnCommand(probe).Returns(0, "DATA1\n", "")
+	mock.OnCommand("test -f " + partialData2).Returns(1, "", "")
+	mock.OnCommand(mkdir2).Returns(0, "", "")
+	mock.OnCommand(create2).Returns(0, "ok\n", "")
+	mock.OnCommand(mv2).Returns(0, "", "")
+
+	spec := AsmDiskLabelSpec{
+		Target:         "ext3adm1",
+		GridHome:       "/u01/app/19c/grid",
+		OracleBase:     "/u01/app/grid",
+		Implementation: AsmDiskLabelImplAsmlib,
+		Labels: []AsmLabelEntry{
+			{Name: "DATA1", Device: "/dev/sdb"},
+			{Name: "DATA2", Device: "/dev/sdc"},
+		},
+	}
+	res, err := asmDiskLabelWithExec(context.Background(), mock, spec, false)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Len(t, res.Labels, 2)
+	assert.True(t, res.Labels[0].Skipped)
+	assert.Equal(t, DetectionStateInstalled, res.Labels[0].Detected)
+	assert.False(t, res.Labels[1].Skipped)
+	assert.Equal(t, DetectionStateInstalled, res.Labels[1].Detected)
+}
+
+// asmLabelCtxCancelExec mimics netcaCtxCancelExec: lets the first N
+// probe calls go through, then cancels ctx and fails the (N+1)-th call.
+type asmLabelCtxCancelExec struct {
+	inner       host.Executor
+	cancelAfter int
+	calls       int
+	cancel      context.CancelFunc
+	wrapErr     error
+}
+
+func (e *asmLabelCtxCancelExec) Run(ctx context.Context, cmd string) (*host.RunResult, error) {
+	e.calls++
+	if e.calls <= e.cancelAfter {
+		return e.inner.Run(ctx, cmd)
+	}
+	if e.cancel != nil {
+		e.cancel()
+	}
+	return nil, e.wrapErr
+}
+
+func TestAsmDiskLabel_CtxCancelled_ReportsPartial(t *testing.T) {
+	const installed = "/u01/app/grid/cfgtoollogs/dbx/asm-label.DATA1.installed"
+	const partial = "/u01/app/grid/cfgtoollogs/dbx/asm-label.DATA1.partial"
+	const probe = "/usr/sbin/oracleasm listdisks"
+	const mkdir = "mkdir -p /u01/app/grid/cfgtoollogs/dbx && : > /u01/app/grid/cfgtoollogs/dbx/asm-label.DATA1.partial"
+
+	mock := hosttest.NewMockExecutor()
+	mock.OnCommand("test -f " + installed).Returns(1, "", "")
+	mock.OnCommand(probe).Returns(0, "OTHER\n", "")
+	mock.OnCommand("test -f " + partial).Returns(1, "", "")
+	mock.OnCommand(mkdir).Returns(0, "", "")
+	// createdisk call is intercepted and ctx-cancelled by the wrapper.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ex := &asmLabelCtxCancelExec{
+		inner:       mock,
+		cancelAfter: 4, // 3 probes + 1 sentinel-write
+		cancel:      cancel,
+		wrapErr:     errors.New("transport: connection closed"),
+	}
+
+	res, err := asmDiskLabelWithExec(ctx, ex, validAsmlibSpec(), false)
+	require.Error(t, err)
+	require.NotNil(t, res)
+	require.Len(t, res.Labels, 1)
+	assert.Equal(t, DetectionStatePartial, res.Labels[0].Detected)
+	assert.Contains(t, err.Error(), "interrupted")
+	assert.Contains(t, err.Error(), "may still be running")
+}

--- a/pkg/provision/install/asmca.go
+++ b/pkg/provision/install/asmca.go
@@ -1,0 +1,193 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/itunified-io/dbx/pkg/host"
+)
+
+// asmcaSentinelDir is the directory under OracleBase where dbx writes
+// the two-phase sentinel files. Per package godoc, this is the
+// canonical location for non-idempotent install primitives.
+const asmcaSentinelDir = "/cfgtoollogs/dbx"
+
+// AsmcaSilent creates an initial ASM diskgroup via `asmca -silent`.
+// Used ONLY for the first DG creation during Phase D.1; subsequent
+// diskgroup operations should go through mcp-oracle-ee-asm tools.
+//
+// Idempotency: NON-IDEMPOTENT primitive — uses the two-phase sentinel
+// pattern documented in the install package godoc. Detection is
+// version-agnostic (file existence only); the version routing happens
+// at the caller via the OracleHome path.
+//
+// Reset semantics (MVP): --reset on Installed/Partial state prints a
+// manual runbook to stderr and returns Skipped. Destructive
+// `drop diskgroup <name> including contents` is deferred to a reverter
+// follow-up plan; this primitive does NOT delete diskgroups.
+func AsmcaSilent(ctx context.Context, spec AsmcaSpec, reset bool) (*InstallResult, error) {
+	exec, err := newSSHExecutor(ctx, spec.Target)
+	if err != nil {
+		return nil, fmt.Errorf("install: ssh to %s: %w", spec.Target, err)
+	}
+	return asmcaSilentWithExec(ctx, exec, spec, reset)
+}
+
+// asmcaSilentWithExec is the testable core. Takes an injected executor
+// so unit tests can use hosttest.MockExecutor.
+func asmcaSilentWithExec(ctx context.Context, exec host.Executor, spec AsmcaSpec, reset bool) (*InstallResult, error) {
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+
+	partialPath, installedPath := asmcaSentinelPaths(spec)
+
+	state, err := detectAsmcaState(ctx, exec, partialPath, installedPath)
+	if err != nil {
+		return nil, fmt.Errorf("install: detect asmca state on %s: %w", spec.Target, err)
+	}
+
+	res := &InstallResult{Detected: state}
+
+	switch state {
+	case DetectionStateInstalled:
+		if !reset {
+			res.Skipped = true
+			return res, nil
+		}
+		fmt.Fprint(os.Stderr, asmcaResetRunbook(spec, "installed", installedPath))
+		res.Skipped = true
+		return res, nil
+	case DetectionStatePartial:
+		if !reset {
+			return res, fmt.Errorf("install: partial asmca state on %s (sentinel %s present without %s); rerun with --reset to print recovery runbook", spec.Target, partialPath, installedPath)
+		}
+		fmt.Fprint(os.Stderr, asmcaResetRunbook(spec, "partial", partialPath))
+		res.Skipped = true
+		return res, nil
+	case DetectionStateAbsent:
+		// fall through
+	}
+
+	// Phase 1: write .partial sentinel BEFORE invoking asmca.
+	mkdirCmd := fmt.Sprintf("mkdir -p %s && : > %s",
+		shellEscape(asmcaSentinelRoot(spec)),
+		shellEscape(partialPath),
+	)
+	if _, err := exec.Run(ctx, mkdirCmd); err != nil {
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("install: asmca sentinel-write interrupted (ctx %v) on %s: %w", ctx.Err(), spec.Target, err)
+		}
+		return nil, fmt.Errorf("install: write asmca .partial sentinel on %s: %w", spec.Target, err)
+	}
+
+	// Phase 2: invoke asmca -silent -createDiskGroup ...
+	cmd := fmt.Sprintf("%s/bin/asmca -silent -createDiskGroup -diskGroupName %s -diskList %s -redundancy %s -au_size %d",
+		shellEscape(spec.OracleHome),
+		shellEscape(spec.DGName),
+		strings.Join(spec.Disks, ","),
+		spec.Redundancy,
+		spec.AUSizeMB,
+	)
+	runRes, err := exec.Run(ctx, cmd)
+	if err != nil {
+		// Local context cancelled mid-run: remote process may still be
+		// running. .partial sentinel persists so next probe sees Partial.
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("install: asmca interrupted (ctx %v); remote process may still be running on %s; next run will see partial state: %w", ctx.Err(), spec.Target, err)
+		}
+		return nil, fmt.Errorf("install: asmca transport failure on %s: %w", spec.Target, err)
+	}
+	res.ExitCode = runRes.ExitCode
+	res.LogTail = tailLog(runRes.Stdout+runRes.Stderr, 100)
+	if runRes.ExitCode != 0 {
+		// Non-zero exit: leave .partial in place so operator runs reverter.
+		res.Detected = DetectionStatePartial
+		return res, fmt.Errorf("install: asmca exit %d on %s", runRes.ExitCode, spec.Target)
+	}
+
+	// Phase 3: atomic rename .partial → .installed (mv is atomic on a
+	// single filesystem; touch is not).
+	mvCmd := fmt.Sprintf("mv %s %s", shellEscape(partialPath), shellEscape(installedPath))
+	if _, err := exec.Run(ctx, mvCmd); err != nil {
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("install: asmca sentinel-rename interrupted (ctx %v) on %s: %w", ctx.Err(), spec.Target, err)
+		}
+		return nil, fmt.Errorf("install: rename asmca sentinel on %s: %w", spec.Target, err)
+	}
+	res.Detected = DetectionStateInstalled
+	return res, nil
+}
+
+// detectAsmcaState reads the two-phase sentinel pair:
+//
+//	.installed present                 → Installed
+//	.partial present without .installed → Partial
+//	neither                             → Absent
+//
+// Detection is version-agnostic: file existence only, no content match.
+func detectAsmcaState(ctx context.Context, exec host.Executor, partialPath, installedPath string) (DetectionState, error) {
+	hasInstalled, err := probeFile(ctx, exec, installedPath)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if hasInstalled {
+		return DetectionStateInstalled, nil
+	}
+	hasPartial, err := probeFile(ctx, exec, partialPath)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if hasPartial {
+		return DetectionStatePartial, nil
+	}
+	return DetectionStateAbsent, nil
+}
+
+// asmcaSentinelRoot returns the directory under OracleBase that holds
+// dbx sentinel files for this primitive.
+func asmcaSentinelRoot(spec AsmcaSpec) string {
+	return spec.OracleBase + asmcaSentinelDir
+}
+
+// asmcaSentinelPaths returns (partialPath, installedPath) keyed on
+// the diskgroup name so multiple DG creations on the same host don't
+// collide.
+func asmcaSentinelPaths(spec AsmcaSpec) (string, string) {
+	root := asmcaSentinelRoot(spec)
+	dg := strings.ToUpper(spec.DGName)
+	return root + "/asmca." + dg + ".partial",
+		root + "/asmca." + dg + ".installed"
+}
+
+// asmcaResetRunbook returns a manual recovery runbook string that the
+// caller prints to stderr when --reset is invoked. The MVP does NOT
+// drop the diskgroup; the operator must do that themselves.
+func asmcaResetRunbook(spec AsmcaSpec, state, sentinelPath string) string {
+	return fmt.Sprintf(`# asmca --reset (MANUAL RUNBOOK; non-destructive in MVP)
+#
+# State on %s: %s
+# Sentinel:   %s
+# Diskgroup:  %s
+#
+# This primitive will NOT drop the diskgroup automatically.
+# Manual recovery procedure:
+#
+#   1. Confirm no databases are mounted against %s:
+#        sqlplus -s / as sysasm <<<'select instance_name from v$asm_client where group_number = (select group_number from v$asm_diskgroup where name=upper('"'"'%s'"'"'));'
+#
+#   2. (Operator) drop the diskgroup:
+#        sqlplus -s / as sysasm <<<'drop diskgroup %s including contents;'
+#
+#   3. Remove the dbx sentinel:
+#        rm -f %s
+#
+#   4. Re-run dbxcli provision install asmca (without --reset).
+#
+`, spec.Target, state, sentinelPath, spec.DGName, spec.DGName, spec.DGName, spec.DGName, sentinelPath)
+}

--- a/pkg/provision/install/asmca.go
+++ b/pkg/provision/install/asmca.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/otel"
 )
 
 // asmcaSentinelDir is the directory under OracleBase where dbx writes
@@ -37,7 +38,15 @@ func AsmcaSilent(ctx context.Context, spec AsmcaSpec, reset bool) (*InstallResul
 
 // asmcaSilentWithExec is the testable core. Takes an injected executor
 // so unit tests can use hosttest.MockExecutor.
-func asmcaSilentWithExec(ctx context.Context, exec host.Executor, spec AsmcaSpec, reset bool) (*InstallResult, error) {
+func asmcaSilentWithExec(ctx context.Context, exec host.Executor, spec AsmcaSpec, reset bool) (res *InstallResult, retErr error) {
+	sb := otel.NewSpan("provision.install.asmca", "dbxcli").
+		WithAttrs(
+			otel.StringAttr(otel.AttrDbxHost, spec.Target),
+			otel.StringAttr(otel.AttrDbxEntityType, "asm_diskgroup"),
+			otel.StringAttr(otel.AttrDbxEntityName, spec.DGName),
+		)
+	defer func() { emitSpan(ctx, sb, retErr) }()
+
 	if err := spec.Validate(); err != nil {
 		return nil, err
 	}
@@ -49,7 +58,7 @@ func asmcaSilentWithExec(ctx context.Context, exec host.Executor, spec AsmcaSpec
 		return nil, fmt.Errorf("install: detect asmca state on %s: %w", spec.Target, err)
 	}
 
-	res := &InstallResult{Detected: state}
+	res = &InstallResult{Detected: state}
 
 	switch state {
 	case DetectionStateInstalled:

--- a/pkg/provision/install/asmca.go
+++ b/pkg/provision/install/asmca.go
@@ -88,7 +88,7 @@ func asmcaSilentWithExec(ctx context.Context, exec host.Executor, spec AsmcaSpec
 	cmd := fmt.Sprintf("%s/bin/asmca -silent -createDiskGroup -diskGroupName %s -diskList %s -redundancy %s -au_size %d",
 		shellEscape(spec.OracleHome),
 		shellEscape(spec.DGName),
-		strings.Join(spec.Disks, ","),
+		shellEscape(strings.Join(spec.Disks, ",")),
 		spec.Redundancy,
 		spec.AUSizeMB,
 	)

--- a/pkg/provision/install/asmca_test.go
+++ b/pkg/provision/install/asmca_test.go
@@ -33,6 +33,10 @@ func TestAsmcaSilent(t *testing.T) {
 	const asmca = "/u01/app/19c/grid/bin/asmca -silent -createDiskGroup -diskGroupName DATA -diskList /dev/sdb,/dev/sdc -redundancy EXTERNAL -au_size 4"
 	const mv = "mv /u01/app/grid/cfgtoollogs/dbx/asmca.DATA.partial /u01/app/grid/cfgtoollogs/dbx/asmca.DATA.installed"
 
+	// Test cases use DetectionStateUnset (-1) for wantDetected when the
+	// case does not need to assert a specific Detected value. The zero
+	// value of DetectionState is Absent, so we cannot use 0 as a "don't
+	// care" sentinel — that would silently skip Absent assertions.
 	cases := []struct {
 		name            string
 		setupMock       func(*hosttest.MockExecutor)
@@ -117,7 +121,8 @@ func TestAsmcaSilent(t *testing.T) {
 				InstallSpec: InstallSpec{OracleHome: "/x", OracleBase: "/y"},
 				DGName:      "D", Redundancy: "EXTERNAL", AUSizeMB: 4, Disks: []string{"/d"},
 			},
-			wantErr: "target is required",
+			wantErr:      "target is required",
+			wantDetected: DetectionStateUnset,
 		},
 		{
 			name:      "RejectsMissingOracleBase",
@@ -126,7 +131,8 @@ func TestAsmcaSilent(t *testing.T) {
 				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x"},
 				DGName:      "D", Redundancy: "EXTERNAL", AUSizeMB: 4, Disks: []string{"/d"},
 			},
-			wantErr: "oracle_base is required",
+			wantErr:      "oracle_base is required",
+			wantDetected: DetectionStateUnset,
 		},
 		{
 			name:      "RejectsMissingDGName",
@@ -135,7 +141,8 @@ func TestAsmcaSilent(t *testing.T) {
 				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
 				Redundancy:  "EXTERNAL", AUSizeMB: 4, Disks: []string{"/d"},
 			},
-			wantErr: "dg_name is required",
+			wantErr:      "dg_name is required",
+			wantDetected: DetectionStateUnset,
 		},
 		{
 			name:      "RejectsBadRedundancy",
@@ -144,7 +151,8 @@ func TestAsmcaSilent(t *testing.T) {
 				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
 				DGName:      "D", Redundancy: "BOGUS", AUSizeMB: 4, Disks: []string{"/d"},
 			},
-			wantErr: "EXTERNAL/NORMAL/HIGH",
+			wantErr:      "EXTERNAL/NORMAL/HIGH",
+			wantDetected: DetectionStateUnset,
 		},
 		{
 			name:      "RejectsZeroAUSize",
@@ -153,7 +161,8 @@ func TestAsmcaSilent(t *testing.T) {
 				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
 				DGName:      "D", Redundancy: "EXTERNAL", AUSizeMB: 0, Disks: []string{"/d"},
 			},
-			wantErr: "au_size_mb",
+			wantErr:      "au_size_mb",
+			wantDetected: DetectionStateUnset,
 		},
 		{
 			name:      "RejectsEmptyDisks",
@@ -162,7 +171,8 @@ func TestAsmcaSilent(t *testing.T) {
 				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
 				DGName:      "D", Redundancy: "EXTERNAL", AUSizeMB: 4,
 			},
-			wantErr: "disks list is required",
+			wantErr:      "disks list is required",
+			wantDetected: DetectionStateUnset,
 		},
 		{
 			name:      "RejectsCommaInDisk",
@@ -172,7 +182,19 @@ func TestAsmcaSilent(t *testing.T) {
 				DGName:      "D", Redundancy: "EXTERNAL", AUSizeMB: 4,
 				Disks: []string{"/dev/sdb,/dev/sdc"},
 			},
-			wantErr: "control character or comma",
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsDiskWithShellMetachar",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmcaSpec{
+				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				DGName:      "D", Redundancy: "EXTERNAL", AUSizeMB: 4,
+				Disks: []string{"/dev/sdb;rm -rf /"},
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
 		},
 	}
 
@@ -187,7 +209,7 @@ func TestAsmcaSilent(t *testing.T) {
 				if tc.wantLogContains != "" && res != nil {
 					assert.Contains(t, res.LogTail, tc.wantLogContains)
 				}
-				if tc.wantDetected != 0 && res != nil {
+				if tc.wantDetected != DetectionStateUnset && res != nil {
 					assert.Equal(t, tc.wantDetected, res.Detected)
 				}
 				return

--- a/pkg/provision/install/asmca_test.go
+++ b/pkg/provision/install/asmca_test.go
@@ -1,0 +1,255 @@
+package install
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/host/hosttest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validAsmcaSpec returns a minimal valid spec usable across tests.
+func validAsmcaSpec() AsmcaSpec {
+	return AsmcaSpec{
+		InstallSpec: InstallSpec{
+			Target:     "ext3adm1",
+			OracleHome: "/u01/app/19c/grid",
+			OracleBase: "/u01/app/grid",
+		},
+		DGName:     "DATA",
+		Redundancy: "EXTERNAL",
+		AUSizeMB:   4,
+		Disks:      []string{"/dev/sdb", "/dev/sdc"},
+	}
+}
+
+func TestAsmcaSilent(t *testing.T) {
+	const partial = "/u01/app/grid/cfgtoollogs/dbx/asmca.DATA.partial"
+	const installed = "/u01/app/grid/cfgtoollogs/dbx/asmca.DATA.installed"
+	const mkdir = "mkdir -p /u01/app/grid/cfgtoollogs/dbx && : > /u01/app/grid/cfgtoollogs/dbx/asmca.DATA.partial"
+	const asmca = "/u01/app/19c/grid/bin/asmca -silent -createDiskGroup -diskGroupName DATA -diskList /dev/sdb,/dev/sdc -redundancy EXTERNAL -au_size 4"
+	const mv = "mv /u01/app/grid/cfgtoollogs/dbx/asmca.DATA.partial /u01/app/grid/cfgtoollogs/dbx/asmca.DATA.installed"
+
+	cases := []struct {
+		name            string
+		setupMock       func(*hosttest.MockExecutor)
+		spec            AsmcaSpec
+		reset           bool
+		wantErr         string
+		wantSkipped     bool
+		wantDetected    DetectionState
+		wantLogContains string
+	}{
+		{
+			name: "InstalledSentinelDetected_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(0, "", "")
+			},
+			spec:         validAsmcaSpec(),
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "PartialSentinelDetected_ReturnsError",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand("test -f " + partial).Returns(0, "", "")
+			},
+			spec:         validAsmcaSpec(),
+			wantErr:      "partial asmca state",
+			wantDetected: DetectionStatePartial,
+		},
+		{
+			name: "AbsentSentinel_RunsFullPipeline",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand("test -f " + partial).Returns(1, "", "")
+				m.OnCommand(mkdir).Returns(0, "", "")
+				m.OnCommand(asmca).Returns(0, "Disk Group DATA created successfully.\n", "")
+				m.OnCommand(mv).Returns(0, "", "")
+			},
+			spec:            validAsmcaSpec(),
+			wantSkipped:     false,
+			wantDetected:    DetectionStateInstalled,
+			wantLogContains: "created successfully",
+		},
+		{
+			name: "AsmcaExitNonzero_LeavesPartialAndErrors",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand("test -f " + partial).Returns(1, "", "")
+				m.OnCommand(mkdir).Returns(0, "", "")
+				m.OnCommand(asmca).Returns(1, "ERROR: ASMCA-08105 Insufficient disks\n", "")
+			},
+			spec:            validAsmcaSpec(),
+			wantErr:         "exit 1",
+			wantDetected:    DetectionStatePartial,
+			wantLogContains: "ASMCA-08105",
+		},
+		{
+			name: "Reset_PrintsRunbook_OnInstalled_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(0, "", "")
+			},
+			spec:         validAsmcaSpec(),
+			reset:        true,
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "Reset_OnPartial_PrintsRunbook_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand("test -f " + partial).Returns(0, "", "")
+			},
+			spec:         validAsmcaSpec(),
+			reset:        true,
+			wantSkipped:  true,
+			wantDetected: DetectionStatePartial,
+		},
+		{
+			name:      "RejectsMissingTarget",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmcaSpec{
+				InstallSpec: InstallSpec{OracleHome: "/x", OracleBase: "/y"},
+				DGName:      "D", Redundancy: "EXTERNAL", AUSizeMB: 4, Disks: []string{"/d"},
+			},
+			wantErr: "target is required",
+		},
+		{
+			name:      "RejectsMissingOracleBase",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmcaSpec{
+				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x"},
+				DGName:      "D", Redundancy: "EXTERNAL", AUSizeMB: 4, Disks: []string{"/d"},
+			},
+			wantErr: "oracle_base is required",
+		},
+		{
+			name:      "RejectsMissingDGName",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmcaSpec{
+				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				Redundancy:  "EXTERNAL", AUSizeMB: 4, Disks: []string{"/d"},
+			},
+			wantErr: "dg_name is required",
+		},
+		{
+			name:      "RejectsBadRedundancy",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmcaSpec{
+				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				DGName:      "D", Redundancy: "BOGUS", AUSizeMB: 4, Disks: []string{"/d"},
+			},
+			wantErr: "EXTERNAL/NORMAL/HIGH",
+		},
+		{
+			name:      "RejectsZeroAUSize",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmcaSpec{
+				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				DGName:      "D", Redundancy: "EXTERNAL", AUSizeMB: 0, Disks: []string{"/d"},
+			},
+			wantErr: "au_size_mb",
+		},
+		{
+			name:      "RejectsEmptyDisks",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmcaSpec{
+				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				DGName:      "D", Redundancy: "EXTERNAL", AUSizeMB: 4,
+			},
+			wantErr: "disks list is required",
+		},
+		{
+			name:      "RejectsCommaInDisk",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: AsmcaSpec{
+				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				DGName:      "D", Redundancy: "EXTERNAL", AUSizeMB: 4,
+				Disks: []string{"/dev/sdb,/dev/sdc"},
+			},
+			wantErr: "control character or comma",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := hosttest.NewMockExecutor()
+			tc.setupMock(mock)
+			res, err := asmcaSilentWithExec(context.Background(), mock, tc.spec, tc.reset)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				if tc.wantLogContains != "" && res != nil {
+					assert.Contains(t, res.LogTail, tc.wantLogContains)
+				}
+				if tc.wantDetected != 0 && res != nil {
+					assert.Equal(t, tc.wantDetected, res.Detected)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			assert.Equal(t, tc.wantSkipped, res.Skipped)
+			assert.Equal(t, tc.wantDetected, res.Detected)
+			if tc.wantLogContains != "" {
+				assert.Contains(t, res.LogTail, tc.wantLogContains)
+			}
+		})
+	}
+}
+
+// asmcaCtxCancelExec mimics rootsh_test.go's helper: lets the first N
+// probe calls go to the inner mock, then cancels ctx and fails the
+// (N+1)-th call to simulate a transport disconnect mid-run.
+type asmcaCtxCancelExec struct {
+	inner       host.Executor
+	cancelAfter int // number of inner calls before cancelling
+	calls       int
+	cancel      context.CancelFunc
+	wrapErr     error
+}
+
+func (e *asmcaCtxCancelExec) Run(ctx context.Context, cmd string) (*host.RunResult, error) {
+	e.calls++
+	if e.calls <= e.cancelAfter {
+		return e.inner.Run(ctx, cmd)
+	}
+	if e.cancel != nil {
+		e.cancel()
+	}
+	return nil, e.wrapErr
+}
+
+func TestAsmcaSilent_CtxCancelled_ReportsPartial(t *testing.T) {
+	const partial = "/u01/app/grid/cfgtoollogs/dbx/asmca.DATA.partial"
+	const installed = "/u01/app/grid/cfgtoollogs/dbx/asmca.DATA.installed"
+	const mkdir = "mkdir -p /u01/app/grid/cfgtoollogs/dbx && : > /u01/app/grid/cfgtoollogs/dbx/asmca.DATA.partial"
+
+	mock := hosttest.NewMockExecutor()
+	// detection: both probes report absent
+	mock.OnCommand("test -f " + installed).Returns(1, "", "")
+	mock.OnCommand("test -f " + partial).Returns(1, "", "")
+	// sentinel write: succeeds (so .partial exists on the host)
+	mock.OnCommand(mkdir).Returns(0, "", "")
+	// asmca call is intercepted and ctx-cancelled by the wrapper
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ex := &asmcaCtxCancelExec{
+		inner:       mock,
+		cancelAfter: 3, // 2 probes + 1 sentinel-write through the inner mock
+		cancel:      cancel,
+		wrapErr:     errors.New("transport: connection closed"),
+	}
+
+	res, err := asmcaSilentWithExec(ctx, ex, validAsmcaSpec(), false)
+	require.Error(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, DetectionStatePartial, res.Detected)
+	assert.Contains(t, err.Error(), "interrupted")
+	assert.Contains(t, err.Error(), "may still be running")
+}

--- a/pkg/provision/install/dbca.go
+++ b/pkg/provision/install/dbca.go
@@ -1,0 +1,229 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/itunified-io/dbx/pkg/host"
+)
+
+// dbcaSentinelDir is the directory under OracleBase where dbx writes the
+// two-phase sentinel files for dbca. Per package godoc, this is the
+// canonical location for non-idempotent install primitives.
+const dbcaSentinelDir = "/cfgtoollogs/dbx"
+
+// DbcaCreateDb creates an Oracle CDB via `dbca -silent -createDatabase`.
+// Phase D.4 of /lab-up — runs after Grid + DB Home + listener and before
+// PDB creation / Data Guard standby cloning.
+//
+// Idempotency: NON-IDEMPOTENT primitive — uses the two-phase sentinel
+// pattern documented in the install package godoc. Detection is
+// version-agnostic (file existence + a `srvctl status database -d <unique>`
+// live probe; no version-string match against stdout — only the binary
+// exit code is consulted).
+//
+// Reset semantics (MVP): --reset on Installed/Partial state prints a
+// manual runbook to stderr and returns Skipped. Destructive
+// `dbca -silent -deleteDatabase` is deferred to a reverter follow-up
+// plan; this primitive does NOT delete databases.
+func DbcaCreateDb(ctx context.Context, spec DbcaCreateDbSpec, reset bool) (*InstallResult, error) {
+	exec, err := newSSHExecutor(ctx, spec.Target)
+	if err != nil {
+		return nil, fmt.Errorf("install: ssh to %s: %w", spec.Target, err)
+	}
+	return dbcaCreateDbWithExec(ctx, exec, spec, reset)
+}
+
+// dbcaCreateDbWithExec is the testable core. Takes an injected executor
+// so unit tests can use hosttest.MockExecutor.
+func dbcaCreateDbWithExec(ctx context.Context, exec host.Executor, spec DbcaCreateDbSpec, reset bool) (*InstallResult, error) {
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+
+	partialPath, installedPath := dbcaSentinelPaths(spec)
+
+	state, err := detectDbcaState(ctx, exec, spec.OracleHome, spec.DbUniqueName, partialPath, installedPath)
+	if err != nil {
+		return nil, fmt.Errorf("install: detect dbca state on %s: %w", spec.Target, err)
+	}
+
+	res := &InstallResult{Detected: state}
+
+	switch state {
+	case DetectionStateInstalled:
+		if !reset {
+			res.Skipped = true
+			return res, nil
+		}
+		fmt.Fprint(os.Stderr, dbcaResetRunbook(spec, "installed", installedPath))
+		res.Skipped = true
+		return res, nil
+	case DetectionStatePartial:
+		if !reset {
+			return res, fmt.Errorf("install: partial dbca state on %s (sentinel %s present without %s); rerun with --reset to print recovery runbook", spec.Target, partialPath, installedPath)
+		}
+		fmt.Fprint(os.Stderr, dbcaResetRunbook(spec, "partial", partialPath))
+		res.Skipped = true
+		return res, nil
+	case DetectionStateAbsent:
+		// fall through
+	}
+
+	// Phase 1: write .partial sentinel BEFORE invoking dbca.
+	mkdirCmd := fmt.Sprintf("mkdir -p %s && : > %s",
+		shellEscape(dbcaSentinelRoot(spec)),
+		shellEscape(partialPath),
+	)
+	if _, err := exec.Run(ctx, mkdirCmd); err != nil {
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("install: dbca sentinel-write interrupted (ctx %v) on %s: %w", ctx.Err(), spec.Target, err)
+		}
+		return nil, fmt.Errorf("install: write dbca .partial sentinel on %s: %w", spec.Target, err)
+	}
+
+	// Phase 2: invoke dbca -silent -createDatabase -responseFile <path>.
+	// Qualify with $ORACLE_HOME and the absolute binary path: non-
+	// interactive SSH sessions on the oracle account do NOT have
+	// $ORACLE_HOME/bin on $PATH, so a bare `dbca` would fail with
+	// "command not found".
+	cmd := fmt.Sprintf("env ORACLE_HOME=%s %s/bin/dbca -silent -createDatabase -responseFile %s",
+		shellEscape(spec.OracleHome),
+		shellEscape(spec.OracleHome),
+		shellEscape(spec.ResponseFilePath),
+	)
+	runRes, err := exec.Run(ctx, cmd)
+	if err != nil {
+		// Local context cancelled mid-run: remote process may still be
+		// running. .partial sentinel persists so next probe sees Partial.
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("install: dbca interrupted (ctx %v); remote process may still be running on %s; next run will see partial state: %w", ctx.Err(), spec.Target, err)
+		}
+		return nil, fmt.Errorf("install: dbca transport failure on %s: %w", spec.Target, err)
+	}
+	res.ExitCode = runRes.ExitCode
+	res.LogTail = tailLog(runRes.Stdout+runRes.Stderr, 100)
+	if runRes.ExitCode != 0 {
+		// Non-zero exit: leave .partial in place so operator runs reverter.
+		res.Detected = DetectionStatePartial
+		return res, fmt.Errorf("install: dbca exit %d on %s", runRes.ExitCode, spec.Target)
+	}
+
+	// Phase 3: atomic rename .partial → .installed.
+	mvCmd := fmt.Sprintf("mv %s %s", shellEscape(partialPath), shellEscape(installedPath))
+	if _, err := exec.Run(ctx, mvCmd); err != nil {
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("install: dbca sentinel-rename interrupted (ctx %v) on %s: %w", ctx.Err(), spec.Target, err)
+		}
+		return nil, fmt.Errorf("install: rename dbca sentinel on %s: %w", spec.Target, err)
+	}
+	res.Detected = DetectionStateInstalled
+	return res, nil
+}
+
+// detectDbcaState reads the two-phase sentinel pair PLUS a live
+// `srvctl status database -d <unique>` probe. The live probe is
+// included so a pre-existing database (created outside dbx) is
+// recognised as Installed without forcing the operator to fabricate
+// a sentinel file.
+//
+//	.installed sentinel present              → Installed
+//	srvctl status database exit 0            → Installed
+//	.partial present without .installed      → Partial
+//	none of the above                        → Absent
+//
+// The srvctl probe is version-agnostic: only the exit code is consulted,
+// never a substring match against stdout. srvctl ships with both the
+// Grid Infrastructure home AND the DB home — we use the DB home path
+// because dbca runs from the DB home and srvctl on that home knows
+// about non-CRS-managed single-instance databases too.
+func detectDbcaState(ctx context.Context, exec host.Executor, oracleHome, dbUniqueName, partialPath, installedPath string) (DetectionState, error) {
+	hasInstalled, err := probeFile(ctx, exec, installedPath)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if hasInstalled {
+		return DetectionStateInstalled, nil
+	}
+	// Live probe — qualify srvctl with $ORACLE_HOME and the absolute
+	// binary path: non-interactive SSH sessions on the oracle account
+	// do NOT have $ORACLE_HOME/bin on $PATH, so a bare `srvctl` would
+	// fail with "command not found" and the probe would mis-report Absent.
+	probeCmd := fmt.Sprintf("env ORACLE_HOME=%s %s/bin/srvctl status database -d %s",
+		shellEscape(oracleHome),
+		shellEscape(oracleHome),
+		shellEscape(dbUniqueName),
+	)
+	live, err := exec.Run(ctx, probeCmd)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if live.ExitCode == 0 {
+		return DetectionStateInstalled, nil
+	}
+	hasPartial, err := probeFile(ctx, exec, partialPath)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if hasPartial {
+		return DetectionStatePartial, nil
+	}
+	return DetectionStateAbsent, nil
+}
+
+// dbcaSentinelRoot returns the directory under OracleBase that holds
+// dbx sentinel files for this primitive.
+func dbcaSentinelRoot(spec DbcaCreateDbSpec) string {
+	return spec.OracleBase + dbcaSentinelDir
+}
+
+// dbcaSentinelPaths returns (partialPath, installedPath) keyed on the
+// DB_UNIQUE_NAME (uppercased) so multiple databases on the same host
+// don't collide.
+func dbcaSentinelPaths(spec DbcaCreateDbSpec) (string, string) {
+	root := dbcaSentinelRoot(spec)
+	u := strings.ToUpper(spec.DbUniqueName)
+	return root + "/dbca." + u + ".partial",
+		root + "/dbca." + u + ".installed"
+}
+
+// dbcaResetRunbook returns a manual recovery runbook string that the
+// caller prints to stderr when --reset is invoked. The MVP does NOT
+// drop the database; the operator must do that themselves via
+// `dbca -silent -deleteDatabase` plus manual datafile cleanup.
+func dbcaResetRunbook(spec DbcaCreateDbSpec, state, sentinelPath string) string {
+	return fmt.Sprintf(`# dbca --reset (MANUAL RUNBOOK; non-destructive in MVP)
+#
+# State on %s: %s
+# Sentinel:   %s
+# Database:   %s (DB_UNIQUE_NAME)
+#
+# This primitive will NOT drop the database automatically.
+# Manual recovery procedure:
+#
+#   1. Confirm no users / standbys depend on %s:
+#        env ORACLE_HOME=%s %s/bin/srvctl status database -d %s
+#        env ORACLE_HOME=%s %s/bin/sqlplus -s / as sysdba <<<'select name, open_mode from v$database;'
+#
+#   2. (Operator) silently delete the database:
+#        env ORACLE_HOME=%s %s/bin/dbca -silent -deleteDatabase -sourceDB %s
+#        # plus manual cleanup of any leftover datafiles / FRA contents
+#        # under the storage destinations declared in the response file.
+#
+#   3. Remove the dbx sentinel:
+#        rm -f %s
+#
+#   4. Re-run dbxcli provision install dbca (without --reset).
+#
+`, spec.Target, state, sentinelPath, spec.DbUniqueName,
+		spec.DbUniqueName,
+		spec.OracleHome, spec.OracleHome, spec.DbUniqueName,
+		spec.OracleHome, spec.OracleHome,
+		spec.OracleHome, spec.OracleHome, spec.DbUniqueName,
+		sentinelPath)
+}

--- a/pkg/provision/install/dbca.go
+++ b/pkg/provision/install/dbca.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/otel"
 )
 
 // dbcaSentinelDir is the directory under OracleBase where dbx writes the
@@ -38,7 +39,16 @@ func DbcaCreateDb(ctx context.Context, spec DbcaCreateDbSpec, reset bool) (*Inst
 
 // dbcaCreateDbWithExec is the testable core. Takes an injected executor
 // so unit tests can use hosttest.MockExecutor.
-func dbcaCreateDbWithExec(ctx context.Context, exec host.Executor, spec DbcaCreateDbSpec, reset bool) (*InstallResult, error) {
+func dbcaCreateDbWithExec(ctx context.Context, exec host.Executor, spec DbcaCreateDbSpec, reset bool) (res *InstallResult, retErr error) {
+	sb := otel.NewSpan("provision.install.dbca_create_db", "dbxcli").
+		WithAttrs(
+			otel.StringAttr(otel.AttrDbxHost, spec.Target),
+			otel.StringAttr(otel.AttrDbxEntityType, "oracle_database"),
+			otel.StringAttr(otel.AttrDbxEntityName, spec.DbUniqueName),
+			otel.StringAttr(otel.AttrDbxDBUniqueName, spec.DbUniqueName),
+		)
+	defer func() { emitSpan(ctx, sb, retErr) }()
+
 	if err := spec.Validate(); err != nil {
 		return nil, err
 	}
@@ -56,7 +66,7 @@ func dbcaCreateDbWithExec(ctx context.Context, exec host.Executor, spec DbcaCrea
 		return nil, fmt.Errorf("install: detect dbca state on %s: %w", spec.Target, err)
 	}
 
-	res := &InstallResult{Detected: state}
+	res = &InstallResult{Detected: state}
 
 	switch state {
 	case DetectionStateInstalled:

--- a/pkg/provision/install/dbca.go
+++ b/pkg/provision/install/dbca.go
@@ -47,6 +47,12 @@ func dbcaCreateDbWithExec(ctx context.Context, exec host.Executor, spec DbcaCrea
 
 	state, err := detectDbcaState(ctx, exec, spec.OracleHome, spec.DbUniqueName, partialPath, installedPath)
 	if err != nil {
+		// If detection reported Partial (e.g. ctx cancelled mid-srvctl probe),
+		// preserve that annotation so the caller sees Partial + error rather
+		// than a bare error.
+		if state == DetectionStatePartial {
+			return &InstallResult{Detected: DetectionStatePartial}, fmt.Errorf("install: detect dbca state on %s: %w", spec.Target, err)
+		}
 		return nil, fmt.Errorf("install: detect dbca state on %s: %w", spec.Target, err)
 	}
 
@@ -161,7 +167,13 @@ func detectDbcaState(ctx context.Context, exec host.Executor, oracleHome, dbUniq
 	)
 	live, err := exec.Run(ctx, probeCmd)
 	if err != nil {
-		return DetectionStateAbsent, err
+		// Distinguish ctx cancel (remote process may still be running →
+		// Partial) from a generic transport error (DB existence unknown →
+		// Absent + error is the honest answer; Partial would be a lie).
+		if ctx.Err() != nil {
+			return DetectionStatePartial, fmt.Errorf("srvctl probe interrupted; remote process may still be running: %w", err)
+		}
+		return DetectionStateAbsent, fmt.Errorf("srvctl probe transport error: %w", err)
 	}
 	if live.ExitCode == 0 {
 		return DetectionStateInstalled, nil

--- a/pkg/provision/install/dbca_test.go
+++ b/pkg/provision/install/dbca_test.go
@@ -293,3 +293,33 @@ func TestDbcaCreateDb_CtxCancelled_ReportsPartial(t *testing.T) {
 	assert.Contains(t, err.Error(), "interrupted")
 	assert.Contains(t, err.Error(), "may still be running")
 }
+
+// TestDetectDbcaState_CtxCancelDuringSrvctl_ReportsPartial covers the case
+// where the srvctl live probe transport-fails because the local context was
+// cancelled. The remote srvctl may still be running, so we report Partial
+// (not Absent) and propagate that annotation up through the caller.
+func TestDetectDbcaState_CtxCancelDuringSrvctl_ReportsPartial(t *testing.T) {
+	const partial = "/u01/app/oracle/cfgtoollogs/dbx/dbca.ORCL.partial"
+	const installed = "/u01/app/oracle/cfgtoollogs/dbx/dbca.ORCL.installed"
+	const srvctl = "env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/srvctl status database -d ORCL"
+
+	mock := hosttest.NewMockExecutor()
+	mock.OnCommand("test -f " + installed).Returns(1, "", "")
+	// srvctl call is intercepted and ctx-cancelled by the wrapper below.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ex := &dbcaCtxCancelExec{
+		inner:       mock,
+		cancelAfter: 1, // 1 probe (installed) + then cancel during srvctl
+		cancel:      cancel,
+		wrapErr:     errors.New("transport: connection closed"),
+	}
+
+	// Direct call into detectDbcaState to verify the unit-level contract.
+	state, err := detectDbcaState(ctx, ex, "/u01/app/oracle/product/19c/dbhome_1", "ORCL", partial, installed)
+	require.Error(t, err)
+	assert.Equal(t, DetectionStatePartial, state)
+	assert.Contains(t, err.Error(), "interrupted")
+	assert.Contains(t, err.Error(), "may still be running")
+	_ = srvctl // referenced for documentation parity with test above
+}

--- a/pkg/provision/install/dbca_test.go
+++ b/pkg/provision/install/dbca_test.go
@@ -1,0 +1,295 @@
+package install
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/host/hosttest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validDbcaSpec returns a minimal valid spec usable across tests.
+func validDbcaSpec() DbcaCreateDbSpec {
+	return DbcaCreateDbSpec{
+		InstallSpec: InstallSpec{
+			Target:           "ext3adm1",
+			OracleHome:       "/u01/app/oracle/product/19c/dbhome_1",
+			OracleBase:       "/u01/app/oracle",
+			ResponseFilePath: "/tmp/dbca.rsp",
+		},
+		DbUniqueName: "ORCL",
+	}
+}
+
+func TestDbcaCreateDb(t *testing.T) {
+	const partial = "/u01/app/oracle/cfgtoollogs/dbx/dbca.ORCL.partial"
+	const installed = "/u01/app/oracle/cfgtoollogs/dbx/dbca.ORCL.installed"
+	const srvctl = "env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/srvctl status database -d ORCL"
+	const mkdir = "mkdir -p /u01/app/oracle/cfgtoollogs/dbx && : > /u01/app/oracle/cfgtoollogs/dbx/dbca.ORCL.partial"
+	const dbca = "env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/dbca -silent -createDatabase -responseFile /tmp/dbca.rsp"
+	const mv = "mv /u01/app/oracle/cfgtoollogs/dbx/dbca.ORCL.partial /u01/app/oracle/cfgtoollogs/dbx/dbca.ORCL.installed"
+
+	cases := []struct {
+		name            string
+		setupMock       func(*hosttest.MockExecutor)
+		spec            DbcaCreateDbSpec
+		reset           bool
+		wantErr         string
+		wantSkipped     bool
+		wantDetected    DetectionState
+		wantLogContains string
+	}{
+		{
+			name: "InstalledSentinelDetected_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(0, "", "")
+			},
+			spec:         validDbcaSpec(),
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "LiveDatabaseDetected_NoSentinel_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(srvctl).Returns(0, "Database is running.\n", "")
+			},
+			spec:         validDbcaSpec(),
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "PartialSentinelDetected_ReturnsError",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(srvctl).Returns(1, "PRCD-1120: ...\n", "")
+				m.OnCommand("test -f " + partial).Returns(0, "", "")
+			},
+			spec:         validDbcaSpec(),
+			wantErr:      "partial dbca state",
+			wantDetected: DetectionStatePartial,
+		},
+		{
+			name: "AbsentDatabase_RunsFullPipeline",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(srvctl).Returns(1, "PRCD-1120: ...\n", "")
+				m.OnCommand("test -f " + partial).Returns(1, "", "")
+				m.OnCommand(mkdir).Returns(0, "", "")
+				m.OnCommand(dbca).Returns(0, "Prepare for db operation\n100% complete\nDatabase creation complete.\n", "")
+				m.OnCommand(mv).Returns(0, "", "")
+			},
+			spec:            validDbcaSpec(),
+			wantSkipped:     false,
+			wantDetected:    DetectionStateInstalled,
+			wantLogContains: "Database creation complete",
+		},
+		{
+			name: "DbcaExitNonzero_LeavesPartialAndErrors",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(srvctl).Returns(1, "PRCD-1120: ...\n", "")
+				m.OnCommand("test -f " + partial).Returns(1, "", "")
+				m.OnCommand(mkdir).Returns(0, "", "")
+				m.OnCommand(dbca).Returns(1, "[FATAL] DBT-06604: insufficient memory\n", "")
+			},
+			spec:            validDbcaSpec(),
+			wantErr:         "exit 1",
+			wantDetected:    DetectionStatePartial,
+			wantLogContains: "DBT-06604",
+		},
+		{
+			name: "Reset_OnInstalled_PrintsRunbook_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(0, "", "")
+			},
+			spec:         validDbcaSpec(),
+			reset:        true,
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "Reset_OnPartial_PrintsRunbook_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(srvctl).Returns(1, "PRCD-1120: ...\n", "")
+				m.OnCommand("test -f " + partial).Returns(0, "", "")
+			},
+			spec:         validDbcaSpec(),
+			reset:        true,
+			wantSkipped:  true,
+			wantDetected: DetectionStatePartial,
+		},
+		{
+			name:      "RejectsMissingResponseFile",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: func() DbcaCreateDbSpec {
+				s := validDbcaSpec()
+				s.ResponseFilePath = ""
+				return s
+			}(),
+			wantErr:      "response_file_path is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsMissingTarget",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: DbcaCreateDbSpec{
+				InstallSpec:  InstallSpec{OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				DbUniqueName: "ORCL",
+			},
+			wantErr:      "target is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsMissingOracleBase",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: DbcaCreateDbSpec{
+				InstallSpec:  InstallSpec{Target: "x", OracleHome: "/x", ResponseFilePath: "/r"},
+				DbUniqueName: "ORCL",
+			},
+			wantErr:      "oracle_base is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsMissingDbUniqueName",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: DbcaCreateDbSpec{
+				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+			},
+			wantErr:      "db_unique_name is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsDbUniqueNameWithShellMetachar_Semicolon",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: DbcaCreateDbSpec{
+				InstallSpec:  InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				DbUniqueName: "ORCL;rm -rf /",
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsDbUniqueNameWithBacktick",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: DbcaCreateDbSpec{
+				InstallSpec:  InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				DbUniqueName: "ORCL`whoami`",
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsDbUniqueNameWithDollar",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: DbcaCreateDbSpec{
+				InstallSpec:  InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				DbUniqueName: "ORCL$(id)",
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsTargetWithNewline",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: DbcaCreateDbSpec{
+				InstallSpec:  InstallSpec{Target: "x\nrm -rf /", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				DbUniqueName: "ORCL",
+			},
+			wantErr:      "control character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsSysPasswordFileWithNewline",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: DbcaCreateDbSpec{
+				InstallSpec:     InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				DbUniqueName:    "ORCL",
+				SysPasswordFile: "/tmp/syspw\nrm -rf /",
+			},
+			wantErr:      "control character",
+			wantDetected: DetectionStateUnset,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := hosttest.NewMockExecutor()
+			tc.setupMock(mock)
+			res, err := dbcaCreateDbWithExec(context.Background(), mock, tc.spec, tc.reset)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				if tc.wantLogContains != "" && res != nil {
+					assert.Contains(t, res.LogTail, tc.wantLogContains)
+				}
+				if tc.wantDetected != DetectionStateUnset && res != nil {
+					assert.Equal(t, tc.wantDetected, res.Detected)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			assert.Equal(t, tc.wantSkipped, res.Skipped)
+			assert.Equal(t, tc.wantDetected, res.Detected)
+			if tc.wantLogContains != "" {
+				assert.Contains(t, res.LogTail, tc.wantLogContains)
+			}
+		})
+	}
+}
+
+// dbcaCtxCancelExec mimics netca_test.go's helper: lets the first N probe
+// calls go to the inner mock, then cancels ctx and fails the (N+1)-th
+// call to simulate a transport disconnect mid-run.
+type dbcaCtxCancelExec struct {
+	inner       host.Executor
+	cancelAfter int
+	calls       int
+	cancel      context.CancelFunc
+	wrapErr     error
+}
+
+func (e *dbcaCtxCancelExec) Run(ctx context.Context, cmd string) (*host.RunResult, error) {
+	e.calls++
+	if e.calls <= e.cancelAfter {
+		return e.inner.Run(ctx, cmd)
+	}
+	if e.cancel != nil {
+		e.cancel()
+	}
+	return nil, e.wrapErr
+}
+
+func TestDbcaCreateDb_CtxCancelled_ReportsPartial(t *testing.T) {
+	const partial = "/u01/app/oracle/cfgtoollogs/dbx/dbca.ORCL.partial"
+	const installed = "/u01/app/oracle/cfgtoollogs/dbx/dbca.ORCL.installed"
+	const srvctl = "env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/srvctl status database -d ORCL"
+	const mkdir = "mkdir -p /u01/app/oracle/cfgtoollogs/dbx && : > /u01/app/oracle/cfgtoollogs/dbx/dbca.ORCL.partial"
+
+	mock := hosttest.NewMockExecutor()
+	mock.OnCommand("test -f " + installed).Returns(1, "", "")
+	mock.OnCommand(srvctl).Returns(1, "PRCD-1120: ...\n", "")
+	mock.OnCommand("test -f " + partial).Returns(1, "", "")
+	mock.OnCommand(mkdir).Returns(0, "", "")
+	// dbca call is intercepted and ctx-cancelled by the wrapper.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ex := &dbcaCtxCancelExec{
+		inner:       mock,
+		cancelAfter: 4, // 3 probes (installed, srvctl, partial) + 1 sentinel-write
+		cancel:      cancel,
+		wrapErr:     errors.New("transport: connection closed"),
+	}
+
+	res, err := dbcaCreateDbWithExec(ctx, ex, validDbcaSpec(), false)
+	require.Error(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, DetectionStatePartial, res.Detected)
+	assert.Contains(t, err.Error(), "interrupted")
+	assert.Contains(t, err.Error(), "may still be running")
+}

--- a/pkg/provision/install/dbhome.go
+++ b/pkg/provision/install/dbhome.go
@@ -60,6 +60,10 @@ func dbhomeInstallWithExec(ctx context.Context, exec host.Executor, spec Install
 		shellEscape(spec.SoftwareStaging), shellEscape(spec.ResponseFilePath))
 	runRes, err := exec.Run(ctx, cmd)
 	if err != nil {
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("runInstaller interrupted (ctx %v); remote process may still be running on %s; next run will see partial state: %w", ctx.Err(), spec.Target, err)
+		}
 		return nil, fmt.Errorf("runInstaller transport failure: %w", err)
 	}
 	res.ExitCode = runRes.ExitCode

--- a/pkg/provision/install/dbhome.go
+++ b/pkg/provision/install/dbhome.go
@@ -1,0 +1,106 @@
+package install
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/itunified-io/dbx/pkg/host"
+)
+
+// DBHomeInstall runs `runInstaller -silent` for an Oracle DB Home on
+// the target host. Caller MUST have rendered + SCPed the response
+// file to spec.ResponseFilePath before calling.
+//
+// Idempotency: if $ORACLE_HOME/bin/oracle exits 0 AND
+// $ORACLE_HOME/OPatch/opatch lsinventory exits 0, returns
+// Skipped=true with Detected=Installed. If only one passes,
+// returns Partial + abort with --reset runbook pointer.
+// Version string is not inspected — binary presence + clean exit
+// is sufficient; version-routing happens at template-selection level.
+func DBHomeInstall(ctx context.Context, spec InstallSpec, reset bool) (*InstallResult, error) {
+	exec, err := newSSHExecutor(ctx, spec.Target)
+	if err != nil {
+		return nil, fmt.Errorf("ssh to %s: %w", spec.Target, err)
+	}
+	return dbhomeInstallWithExec(ctx, exec, spec, reset)
+}
+
+// dbhomeInstallWithExec is the testable core. Takes an injected executor
+// so unit tests can use hosttest.MockExecutor.
+func dbhomeInstallWithExec(ctx context.Context, exec host.Executor, spec InstallSpec, reset bool) (*InstallResult, error) {
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+
+	state, err := detectDBHomeState(ctx, exec, spec.OracleHome)
+	if err != nil {
+		return nil, fmt.Errorf("detect dbhome state on %s: %w", spec.Target, err)
+	}
+
+	res := &InstallResult{Detected: state}
+
+	switch state {
+	case DetectionStateInstalled:
+		if !reset {
+			res.Skipped = true
+			return res, nil
+		}
+		return nil, fmt.Errorf("--reset on installed state requires reverter primitive (not yet shipped); manual deinstall.sh required")
+	case DetectionStatePartial:
+		return nil, fmt.Errorf("partial dbhome install detected on %s; rerun with --reset after manual cleanup, or see runbook", spec.Target)
+	case DetectionStateAbsent:
+		// fall through to runInstaller
+	}
+
+	if spec.ResponseFilePath == "" {
+		return nil, fmt.Errorf("ResponseFilePath required when state=absent")
+	}
+
+	cmd := fmt.Sprintf("%s/runInstaller -silent -responseFile %s -ignorePrereqFailure -waitforcompletion",
+		shellEscape(spec.SoftwareStaging), shellEscape(spec.ResponseFilePath))
+	runRes, err := exec.Run(ctx, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("runInstaller transport failure: %w", err)
+	}
+	res.ExitCode = runRes.ExitCode
+	res.LogTail = tailLog(runRes.Stdout+runRes.Stderr, 100)
+	if runRes.ExitCode != 0 {
+		return res, fmt.Errorf("runInstaller exit %d on %s", runRes.ExitCode, spec.Target)
+	}
+	return res, nil
+}
+
+// detectDBHomeState probes for prior DB home install evidence per the
+// version-agnostic canonical detection rule:
+//   $ORACLE_HOME/bin/oracle -V exits 0
+//   AND $ORACLE_HOME/OPatch/opatch lsinventory exits 0 → installed
+//   exactly one of the two                             → partial
+//   neither                                            → absent
+//
+// The oracle binary's presence + clean exit is sufficient for all
+// supported versions (19c, 21c, 23ai, 26ai). Version-routing is
+// handled at the template-selection level via spec.OracleHome path.
+func detectDBHomeState(ctx context.Context, exec host.Executor, oracleHome string) (DetectionState, error) {
+	binCmd := fmt.Sprintf("%s/bin/oracle -V 2>&1 | head -1", shellEscape(oracleHome))
+	binRes, err := exec.Run(ctx, binCmd)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	hasBin := binRes.ExitCode == 0
+
+	patchCmd := fmt.Sprintf("%s/OPatch/opatch lsinventory 2>&1 | head -5", shellEscape(oracleHome))
+	patchRes, err := exec.Run(ctx, patchCmd)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	hasOPatch := patchRes.ExitCode == 0
+
+	switch {
+	case hasBin && hasOPatch:
+		return DetectionStateInstalled, nil
+	case !hasBin && !hasOPatch:
+		return DetectionStateAbsent, nil
+	default:
+		return DetectionStatePartial, nil
+	}
+}

--- a/pkg/provision/install/dbhome.go
+++ b/pkg/provision/install/dbhome.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/otel"
 )
 
 // DBHomeInstall runs `runInstaller -silent` for an Oracle DB Home on
@@ -27,7 +28,15 @@ func DBHomeInstall(ctx context.Context, spec InstallSpec, reset bool) (*InstallR
 
 // dbhomeInstallWithExec is the testable core. Takes an injected executor
 // so unit tests can use hosttest.MockExecutor.
-func dbhomeInstallWithExec(ctx context.Context, exec host.Executor, spec InstallSpec, reset bool) (*InstallResult, error) {
+func dbhomeInstallWithExec(ctx context.Context, exec host.Executor, spec InstallSpec, reset bool) (res *InstallResult, retErr error) {
+	sb := otel.NewSpan("provision.install.dbhome", "dbxcli").
+		WithAttrs(
+			otel.StringAttr(otel.AttrDbxHost, spec.Target),
+			otel.StringAttr(otel.AttrDbxEntityType, "oracle_db_home"),
+			otel.StringAttr(otel.AttrDbxEntityName, spec.OracleHome),
+		)
+	defer func() { emitSpan(ctx, sb, retErr) }()
+
 	if err := spec.Validate(); err != nil {
 		return nil, err
 	}
@@ -37,7 +46,7 @@ func dbhomeInstallWithExec(ctx context.Context, exec host.Executor, spec Install
 		return nil, fmt.Errorf("detect dbhome state on %s: %w", spec.Target, err)
 	}
 
-	res := &InstallResult{Detected: state}
+	res = &InstallResult{Detected: state}
 
 	switch state {
 	case DetectionStateInstalled:

--- a/pkg/provision/install/dbhome_test.go
+++ b/pkg/provision/install/dbhome_test.go
@@ -1,0 +1,122 @@
+package install
+
+import (
+	"context"
+	"testing"
+
+	"github.com/itunified-io/dbx/pkg/host/hosttest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBHomeInstall(t *testing.T) {
+	cases := []struct {
+		name            string
+		setupMock       func(*hosttest.MockExecutor)
+		spec            InstallSpec
+		reset           bool
+		wantErr         string
+		wantSkipped     bool
+		wantDetected    DetectionState
+		wantLogContains string
+	}{
+		{
+			name: "DetectsExistingInstall_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("/u01/app/oracle/product/19c/dbhome_1/bin/oracle -V 2>&1 | head -1").
+					Returns(0, "Oracle Database 19.0.0.0.0 - Production\nVersion 19.26.0.0.0\n", "")
+				m.OnCommand("/u01/app/oracle/product/19c/dbhome_1/OPatch/opatch lsinventory 2>&1 | head -5").
+					Returns(0, "Oracle Interim Patch Installer version 12.2.0.1.46\n", "")
+			},
+			spec:         InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/oracle/product/19c/dbhome_1"},
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "AbsentState_RunsInstaller",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("/u01/app/oracle/product/19c/dbhome_1/bin/oracle -V 2>&1 | head -1").Returns(127, "", "No such file")
+				m.OnCommand("/u01/app/oracle/product/19c/dbhome_1/OPatch/opatch lsinventory 2>&1 | head -5").Returns(127, "", "")
+				m.OnCommandPattern(`/smb/software/oracle/19c/db_home/runInstaller -silent -responseFile /tmp/dbhome\.rsp.*`).
+					Returns(0, "Successfully Setup Software.\n", "")
+			},
+			spec: InstallSpec{
+				Target:           "ext3adm1",
+				OracleHome:       "/u01/app/oracle/product/19c/dbhome_1",
+				OracleBase:       "/u01/app/oracle",
+				SoftwareStaging:  "/smb/software/oracle/19c/db_home",
+				ResponseFilePath: "/tmp/dbhome.rsp",
+			},
+			wantSkipped:     false,
+			wantDetected:    DetectionStateAbsent,
+			wantLogContains: "Successfully Setup Software",
+		},
+		{
+			name:      "RejectsInvalidSpec",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec:      InstallSpec{},
+			wantErr:   "target is required",
+		},
+		{
+			name: "PartialState_AbortsWithoutReset",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("/u01/app/oracle/product/19c/dbhome_1/bin/oracle -V 2>&1 | head -1").
+					Returns(0, "Oracle Database 19.0.0.0.0\n", "")
+				m.OnCommand("/u01/app/oracle/product/19c/dbhome_1/OPatch/opatch lsinventory 2>&1 | head -5").Returns(127, "", "")
+			},
+			spec:    InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/oracle/product/19c/dbhome_1"},
+			wantErr: "partial dbhome install detected",
+		},
+		{
+			name: "DetectsExistingInstall_Skips_23ai",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("/u01/app/oracle/product/23ai/dbhome_1/bin/oracle -V 2>&1 | head -1").
+					Returns(0, "Oracle Database 23.0.0.0.0 - Production\nVersion 23.5.0.0.0\n", "")
+				m.OnCommand("/u01/app/oracle/product/23ai/dbhome_1/OPatch/opatch lsinventory 2>&1 | head -5").
+					Returns(0, "Oracle Interim Patch Installer version 12.2.0.1.46\n", "")
+			},
+			spec:         InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/oracle/product/23ai/dbhome_1"},
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "RunInstallerNonzero_ReturnsError",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("/u01/app/oracle/product/19c/dbhome_1/bin/oracle -V 2>&1 | head -1").Returns(127, "", "")
+				m.OnCommand("/u01/app/oracle/product/19c/dbhome_1/OPatch/opatch lsinventory 2>&1 | head -5").Returns(127, "", "")
+				m.OnCommandPattern(`.*runInstaller.*`).Returns(254, "INFO: Skipping the prereq checks.\nERROR: Some files failed to copy.\n", "")
+			},
+			spec: InstallSpec{
+				Target:           "ext3adm1",
+				OracleHome:       "/u01/app/oracle/product/19c/dbhome_1",
+				SoftwareStaging:  "/smb/software/oracle/19c/db_home",
+				ResponseFilePath: "/tmp/dbhome.rsp",
+			},
+			wantErr:         "exit 254",
+			wantLogContains: "Some files failed to copy",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := hosttest.NewMockExecutor()
+			tc.setupMock(mock)
+			res, err := dbhomeInstallWithExec(context.Background(), mock, tc.spec, tc.reset)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				if tc.wantLogContains != "" && res != nil {
+					assert.Contains(t, res.LogTail, tc.wantLogContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			assert.Equal(t, tc.wantSkipped, res.Skipped)
+			assert.Equal(t, tc.wantDetected, res.Detected)
+			if tc.wantLogContains != "" {
+				assert.Contains(t, res.LogTail, tc.wantLogContains)
+			}
+		})
+	}
+}

--- a/pkg/provision/install/grid.go
+++ b/pkg/provision/install/grid.go
@@ -60,6 +60,10 @@ func gridInstallWithExec(ctx context.Context, exec host.Executor, spec InstallSp
 		shellEscape(spec.OracleHome), shellEscape(spec.ResponseFilePath))
 	runRes, err := exec.Run(ctx, cmd)
 	if err != nil {
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("runInstaller interrupted (ctx %v); remote process may still be running on %s; next run will see partial state: %w", ctx.Err(), spec.Target, err)
+		}
 		return nil, fmt.Errorf("runInstaller transport failure: %w", err)
 	}
 	res.ExitCode = runRes.ExitCode
@@ -76,7 +80,7 @@ func gridInstallWithExec(ctx context.Context, exec host.Executor, spec InstallSp
 //   one but not the other                                       → partial
 //   neither                                                     → absent
 func detectGridState(ctx context.Context, exec host.Executor, gridHome string) (DetectionState, error) {
-	hasOraInst, _, err := probeFile(ctx, exec, "/etc/oraInst.loc")
+	hasOraInst, err := probeFile(ctx, exec, "/etc/oraInst.loc")
 	if err != nil {
 		return DetectionStateAbsent, err
 	}

--- a/pkg/provision/install/grid.go
+++ b/pkg/provision/install/grid.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/otel"
 )
 
 // GridInstall runs `runInstaller -silent` for Oracle Grid Infrastructure
@@ -27,7 +28,15 @@ func GridInstall(ctx context.Context, spec InstallSpec, reset bool) (*InstallRes
 
 // gridInstallWithExec is the testable core. Takes an injected executor
 // so unit tests can use hosttest.MockExecutor.
-func gridInstallWithExec(ctx context.Context, exec host.Executor, spec InstallSpec, reset bool) (*InstallResult, error) {
+func gridInstallWithExec(ctx context.Context, exec host.Executor, spec InstallSpec, reset bool) (res *InstallResult, retErr error) {
+	sb := otel.NewSpan("provision.install.grid", "dbxcli").
+		WithAttrs(
+			otel.StringAttr(otel.AttrDbxHost, spec.Target),
+			otel.StringAttr(otel.AttrDbxEntityType, "oracle_grid_home"),
+			otel.StringAttr(otel.AttrDbxEntityName, spec.OracleHome),
+		)
+	defer func() { emitSpan(ctx, sb, retErr) }()
+
 	if err := spec.Validate(); err != nil {
 		return nil, err
 	}
@@ -37,7 +46,7 @@ func gridInstallWithExec(ctx context.Context, exec host.Executor, spec InstallSp
 		return nil, fmt.Errorf("detect grid state on %s: %w", spec.Target, err)
 	}
 
-	res := &InstallResult{Detected: state}
+	res = &InstallResult{Detected: state}
 
 	switch state {
 	case DetectionStateInstalled:

--- a/pkg/provision/install/grid.go
+++ b/pkg/provision/install/grid.go
@@ -1,0 +1,130 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/itunified-io/dbx/pkg/host"
+)
+
+// GridInstall runs `runInstaller -silent` for Oracle Grid Infrastructure
+// on the target host. Caller MUST have rendered + SCPed the response
+// file to spec.ResponseFilePath before calling.
+//
+// Idempotency: if /etc/oraInst.loc and $GRID_HOME/inventory both exist
+// and are populated, returns Skipped=true with Detected=Installed.
+// If only one of the two is present (partial), returns an error
+// pointing at --reset.
+func GridInstall(ctx context.Context, spec InstallSpec, reset bool) (*InstallResult, error) {
+	exec, err := newSSHExecutor(ctx, spec.Target)
+	if err != nil {
+		return nil, fmt.Errorf("ssh to %s: %w", spec.Target, err)
+	}
+	return gridInstallWithExec(ctx, exec, spec, reset)
+}
+
+// gridInstallWithExec is the testable core. Takes an injected executor
+// so unit tests can use hosttest.MockExecutor.
+func gridInstallWithExec(ctx context.Context, exec host.Executor, spec InstallSpec, reset bool) (*InstallResult, error) {
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+
+	state, err := detectGridState(ctx, exec, spec.OracleHome)
+	if err != nil {
+		return nil, fmt.Errorf("detect grid state on %s: %w", spec.Target, err)
+	}
+
+	res := &InstallResult{Detected: state}
+
+	switch state {
+	case DetectionStateInstalled:
+		if !reset {
+			res.Skipped = true
+			return res, nil
+		}
+		return nil, fmt.Errorf("--reset on installed state requires reverter primitive (not yet shipped); manual deinstall.sh required")
+	case DetectionStatePartial:
+		return nil, fmt.Errorf("partial install detected on %s (inventory dir incomplete); rerun with --reset after manual cleanup, or see runbook", spec.Target)
+	case DetectionStateAbsent:
+		// fall through to runInstaller
+	}
+
+	if spec.ResponseFilePath == "" {
+		return nil, fmt.Errorf("ResponseFilePath required when state=absent (caller must render + scp the .rsp first)")
+	}
+
+	cmd := fmt.Sprintf("%s/runInstaller -silent -responseFile %s -ignorePrereqFailure",
+		shellEscape(spec.OracleHome), shellEscape(spec.ResponseFilePath))
+	runRes, err := exec.Run(ctx, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("runInstaller transport failure: %w", err)
+	}
+	res.ExitCode = runRes.ExitCode
+	res.LogTail = tailLog(runRes.Stdout+runRes.Stderr, 100)
+	if runRes.ExitCode != 0 {
+		return res, fmt.Errorf("runInstaller exit %d on %s; check log_tail in result", runRes.ExitCode, spec.Target)
+	}
+	return res, nil
+}
+
+// detectGridState probes for prior Grid install evidence per the
+// Oracle 19c canonical detection rule:
+//   /etc/oraInst.loc present  + $GRID_HOME/inventory non-empty → installed
+//   one but not the other                                       → partial
+//   neither                                                     → absent
+func detectGridState(ctx context.Context, exec host.Executor, gridHome string) (DetectionState, error) {
+	hasOraInst, _, err := probeFile(ctx, exec, "/etc/oraInst.loc")
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	hasInventory, err := probeDirNonEmpty(ctx, exec, gridHome+"/inventory")
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	switch {
+	case hasOraInst && hasInventory:
+		return DetectionStateInstalled, nil
+	case !hasOraInst && !hasInventory:
+		return DetectionStateAbsent, nil
+	default:
+		return DetectionStatePartial, nil
+	}
+}
+
+// sshExecutor implements host.Executor using the local ssh binary.
+// Used by GridInstall (the non-test path).
+type sshExecutor struct {
+	target string
+}
+
+func newSSHExecutor(_ context.Context, target string) (host.Executor, error) {
+	if strings.TrimSpace(target) == "" {
+		return nil, fmt.Errorf("target must not be empty")
+	}
+	return &sshExecutor{target: target}, nil
+}
+
+func (e *sshExecutor) Run(ctx context.Context, command string) (*host.RunResult, error) {
+	cmd := exec.CommandContext(ctx, "ssh", e.target, command) //nolint:gosec
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+			err = nil // non-zero exit is not a transport error
+		} else {
+			return nil, err // transport / exec failure
+		}
+	}
+	return &host.RunResult{
+		ExitCode: exitCode,
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+	}, nil
+}

--- a/pkg/provision/install/grid_test.go
+++ b/pkg/provision/install/grid_test.go
@@ -23,7 +23,7 @@ func TestGridInstall(t *testing.T) {
 		{
 			name: "DetectsExistingInstall_Skips",
 			setupMock: func(m *hosttest.MockExecutor) {
-				m.OnCommand("test -f /etc/oraInst.loc && cat /etc/oraInst.loc").
+				m.OnCommand("test -f /etc/oraInst.loc").
 					Returns(0, "inventory_loc=/u01/app/oraInventory\ninst_group=oinstall\n", "")
 				m.OnCommand("test -d /u01/app/19c/grid/inventory && ls -A /u01/app/19c/grid/inventory | head -1").
 					Returns(0, "ContentsXML\n", "")
@@ -35,7 +35,7 @@ func TestGridInstall(t *testing.T) {
 		{
 			name: "AbsentState_RunsInstaller",
 			setupMock: func(m *hosttest.MockExecutor) {
-				m.OnCommand("test -f /etc/oraInst.loc && cat /etc/oraInst.loc").Returns(1, "", "")
+				m.OnCommand("test -f /etc/oraInst.loc").Returns(1, "", "")
 				m.OnCommand("test -d /u01/app/19c/grid/inventory && ls -A /u01/app/19c/grid/inventory | head -1").
 					Returns(1, "", "")
 				m.OnCommandPattern(`/u01/app/19c/grid/runInstaller -silent -responseFile /tmp/grid\.rsp.*`).
@@ -58,7 +58,7 @@ func TestGridInstall(t *testing.T) {
 		{
 			name: "PartialState_AbortsWithoutReset",
 			setupMock: func(m *hosttest.MockExecutor) {
-				m.OnCommand("test -f /etc/oraInst.loc && cat /etc/oraInst.loc").
+				m.OnCommand("test -f /etc/oraInst.loc").
 					Returns(0, "inventory_loc=/u01/app/oraInventory\n", "")
 				m.OnCommand("test -d /u01/app/19c/grid/inventory && ls -A /u01/app/19c/grid/inventory | head -1").
 					Returns(1, "", "")

--- a/pkg/provision/install/grid_test.go
+++ b/pkg/provision/install/grid_test.go
@@ -1,0 +1,90 @@
+package install
+
+import (
+	"context"
+	"testing"
+
+	"github.com/itunified-io/dbx/pkg/host/hosttest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGridInstall(t *testing.T) {
+	cases := []struct {
+		name            string
+		setupMock       func(*hosttest.MockExecutor)
+		spec            InstallSpec
+		reset           bool
+		wantErr         string // empty = no error
+		wantSkipped     bool
+		wantDetected    DetectionState
+		wantLogContains string
+	}{
+		{
+			name: "DetectsExistingInstall_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f /etc/oraInst.loc && cat /etc/oraInst.loc").
+					Returns(0, "inventory_loc=/u01/app/oraInventory\ninst_group=oinstall\n", "")
+				m.OnCommand("test -d /u01/app/19c/grid/inventory && ls -A /u01/app/19c/grid/inventory | head -1").
+					Returns(0, "ContentsXML\n", "")
+			},
+			spec:         InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/grid", OracleBase: "/u01/app/grid"},
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "AbsentState_RunsInstaller",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f /etc/oraInst.loc && cat /etc/oraInst.loc").Returns(1, "", "")
+				m.OnCommand("test -d /u01/app/19c/grid/inventory && ls -A /u01/app/19c/grid/inventory | head -1").
+					Returns(1, "", "")
+				m.OnCommandPattern(`/u01/app/19c/grid/runInstaller -silent -responseFile /tmp/grid\.rsp.*`).
+					Returns(0, "Installation Successful.\n", "")
+			},
+			spec: InstallSpec{
+				Target: "ext3adm1", OracleHome: "/u01/app/19c/grid",
+				OracleBase: "/u01/app/grid", ResponseFilePath: "/tmp/grid.rsp",
+			},
+			wantSkipped:     false,
+			wantDetected:    DetectionStateAbsent,
+			wantLogContains: "Installation Successful",
+		},
+		{
+			name:      "RejectsInvalidSpec",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec:      InstallSpec{},
+			wantErr:   "target is required",
+		},
+		{
+			name: "PartialState_AbortsWithoutReset",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f /etc/oraInst.loc && cat /etc/oraInst.loc").
+					Returns(0, "inventory_loc=/u01/app/oraInventory\n", "")
+				m.OnCommand("test -d /u01/app/19c/grid/inventory && ls -A /u01/app/19c/grid/inventory | head -1").
+					Returns(1, "", "")
+			},
+			spec:    InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/grid"},
+			wantErr: "partial install detected",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := hosttest.NewMockExecutor()
+			tc.setupMock(mock)
+			res, err := gridInstallWithExec(context.Background(), mock, tc.spec, tc.reset)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			assert.Equal(t, tc.wantSkipped, res.Skipped)
+			assert.Equal(t, tc.wantDetected, res.Detected)
+			if tc.wantLogContains != "" {
+				assert.Contains(t, res.LogTail, tc.wantLogContains)
+			}
+		})
+	}
+}

--- a/pkg/provision/install/helpers.go
+++ b/pkg/provision/install/helpers.go
@@ -1,0 +1,66 @@
+// Package install ships Oracle install primitives — runInstaller,
+// root.sh, asmca, netca, oracleasm/afd disk labeling — invoked by
+// /lab-up Phase D skills via dbxcli provision install <action>.
+//
+// All functions in this package require Enterprise license tier
+// (license.RequireTier checked at the cobra layer, not here).
+package install
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/itunified-io/dbx/pkg/host"
+)
+
+// probeFile checks whether a file exists on the target host and returns
+// its content. Used by detection probes (e.g., cat /etc/oraInst.loc).
+func probeFile(ctx context.Context, exec host.Executor, path string) (exists bool, content string, err error) {
+	cmd := fmt.Sprintf("test -f %s && cat %s", shellEscape(path), shellEscape(path))
+	res, err := exec.Run(ctx, cmd)
+	if err != nil {
+		return false, "", err
+	}
+	if res.ExitCode != 0 {
+		return false, "", nil
+	}
+	return true, res.Stdout, nil
+}
+
+// probeDirNonEmpty returns true when the directory exists and contains
+// at least one entry. Used to detect partial installs (inventory dir
+// present but missing files).
+func probeDirNonEmpty(ctx context.Context, exec host.Executor, path string) (bool, error) {
+	cmd := fmt.Sprintf("test -d %s && ls -A %s | head -1", shellEscape(path), shellEscape(path))
+	res, err := exec.Run(ctx, cmd)
+	if err != nil {
+		return false, err
+	}
+	if res.ExitCode != 0 {
+		return false, nil
+	}
+	return strings.TrimSpace(res.Stdout) != "", nil
+}
+
+// tailLog returns the last n lines of s. Used to attach installer
+// stdout/stderr to InstallResult without ballooning audit records.
+// A trailing newline is stripped before splitting so that "line\nline\n"
+// is treated as 2 lines, not 3.
+func tailLog(s string, n int) string {
+	s = strings.TrimRight(s, "\n")
+	lines := strings.Split(s, "\n")
+	if len(lines) <= n {
+		return strings.Join(lines, "\n") + "\n"
+	}
+	return strings.Join(lines[len(lines)-n:], "\n") + "\n"
+}
+
+// shellEscape wraps a path in single quotes and escapes embedded single
+// quotes — sufficient for paths that MAY contain spaces but never quotes.
+func shellEscape(s string) string {
+	if !strings.ContainsAny(s, " \t'\"$\\;|&<>(){}[]*?!#") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/pkg/provision/install/helpers.go
+++ b/pkg/provision/install/helpers.go
@@ -1,9 +1,3 @@
-// Package install ships Oracle install primitives — runInstaller,
-// root.sh, asmca, netca, oracleasm/afd disk labeling — invoked by
-// /lab-up Phase D skills via dbxcli provision install <action>.
-//
-// All functions in this package require Enterprise license tier
-// (license.RequireTier checked at the cobra layer, not here).
 package install
 
 import (
@@ -14,9 +8,28 @@ import (
 	"github.com/itunified-io/dbx/pkg/host"
 )
 
-// probeFile checks whether a file exists on the target host and returns
-// its content. Used by detection probes (e.g., cat /etc/oraInst.loc).
-func probeFile(ctx context.Context, exec host.Executor, path string) (exists bool, content string, err error) {
+// probeFile checks whether a file exists on the target host. It does
+// NOT return file content — InstallResult.LogTail is opaque to
+// secret-redaction, so propagating arbitrary file content into result
+// fields risks leaking credentials, host keys, or other sensitive
+// data into audit records. Callers that genuinely need the bytes (and
+// have separately confirmed the path is non-sensitive) must use
+// probeFileContents.
+func probeFile(ctx context.Context, exec host.Executor, path string) (exists bool, err error) {
+	cmd := fmt.Sprintf("test -f %s", shellEscape(path))
+	res, err := exec.Run(ctx, cmd)
+	if err != nil {
+		return false, err
+	}
+	return res.ExitCode == 0, nil
+}
+
+// probeFileContents returns existence + content. Package-internal
+// only — see probeFile godoc for the redaction rationale. Use this
+// only for paths whose contents are known-safe (well-known Oracle
+// metadata files like /etc/oraInst.loc), and never propagate the
+// returned content into InstallResult or any audit-bound field.
+func probeFileContents(ctx context.Context, exec host.Executor, path string) (exists bool, content string, err error) {
 	cmd := fmt.Sprintf("test -f %s && cat %s", shellEscape(path), shellEscape(path))
 	res, err := exec.Run(ctx, cmd)
 	if err != nil {
@@ -46,8 +59,12 @@ func probeDirNonEmpty(ctx context.Context, exec host.Executor, path string) (boo
 // tailLog returns the last n lines of s. Used to attach installer
 // stdout/stderr to InstallResult without ballooning audit records.
 // A trailing newline is stripped before splitting so that "line\nline\n"
-// is treated as 2 lines, not 3.
+// is treated as 2 lines, not 3. Empty input returns "" (no synthetic
+// trailing newline).
 func tailLog(s string, n int) string {
+	if s == "" {
+		return ""
+	}
 	s = strings.TrimRight(s, "\n")
 	lines := strings.Split(s, "\n")
 	if len(lines) <= n {
@@ -58,8 +75,10 @@ func tailLog(s string, n int) string {
 
 // shellEscape wraps a path in single quotes and escapes embedded single
 // quotes — sufficient for paths that MAY contain spaces but never quotes.
+// Newline + carriage return are treated as escape-triggers as a defense-
+// in-depth measure (InstallSpec.Validate also rejects them earlier).
 func shellEscape(s string) string {
-	if !strings.ContainsAny(s, " \t'\"$\\;|&<>(){}[]*?!#") {
+	if !strings.ContainsAny(s, " \t\n\r'\"$\\;|&<>(){}[]*?!#") {
 		return s
 	}
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"

--- a/pkg/provision/install/helpers_test.go
+++ b/pkg/provision/install/helpers_test.go
@@ -1,0 +1,38 @@
+package install
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/itunified-io/dbx/pkg/host/hosttest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProbeFile_Exists(t *testing.T) {
+	mock := hosttest.NewMockExecutor()
+	mock.OnCommand("test -f /etc/oraInst.loc && cat /etc/oraInst.loc").
+		Returns(0, "inventory_loc=/u01/app/oraInventory\ninst_group=oinstall\n", "")
+
+	exists, content, err := probeFile(context.Background(), mock, "/etc/oraInst.loc")
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Contains(t, content, "inventory_loc=/u01/app/oraInventory")
+}
+
+func TestProbeFile_Absent(t *testing.T) {
+	mock := hosttest.NewMockExecutor()
+	mock.OnCommand("test -f /missing && cat /missing").Returns(1, "", "")
+
+	exists, _, err := probeFile(context.Background(), mock, "/missing")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestTailLog_LimitsLines(t *testing.T) {
+	long := strings.Repeat("line\n", 200)
+	tail := tailLog(long, 100)
+	lines := strings.Count(tail, "\n")
+	assert.Equal(t, 100, lines)
+}

--- a/pkg/provision/install/helpers_test.go
+++ b/pkg/provision/install/helpers_test.go
@@ -12,22 +12,31 @@ import (
 
 func TestProbeFile_Exists(t *testing.T) {
 	mock := hosttest.NewMockExecutor()
-	mock.OnCommand("test -f /etc/oraInst.loc && cat /etc/oraInst.loc").
-		Returns(0, "inventory_loc=/u01/app/oraInventory\ninst_group=oinstall\n", "")
+	mock.OnCommand("test -f /etc/oraInst.loc").Returns(0, "", "")
 
-	exists, content, err := probeFile(context.Background(), mock, "/etc/oraInst.loc")
+	exists, err := probeFile(context.Background(), mock, "/etc/oraInst.loc")
 	require.NoError(t, err)
 	assert.True(t, exists)
-	assert.Contains(t, content, "inventory_loc=/u01/app/oraInventory")
 }
 
 func TestProbeFile_Absent(t *testing.T) {
 	mock := hosttest.NewMockExecutor()
-	mock.OnCommand("test -f /missing && cat /missing").Returns(1, "", "")
+	mock.OnCommand("test -f /missing").Returns(1, "", "")
 
-	exists, _, err := probeFile(context.Background(), mock, "/missing")
+	exists, err := probeFile(context.Background(), mock, "/missing")
 	require.NoError(t, err)
 	assert.False(t, exists)
+}
+
+func TestProbeFileContents_Exists(t *testing.T) {
+	mock := hosttest.NewMockExecutor()
+	mock.OnCommand("test -f /etc/oraInst.loc && cat /etc/oraInst.loc").
+		Returns(0, "inventory_loc=/u01/app/oraInventory\ninst_group=oinstall\n", "")
+
+	exists, content, err := probeFileContents(context.Background(), mock, "/etc/oraInst.loc")
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Contains(t, content, "inventory_loc=/u01/app/oraInventory")
 }
 
 func TestTailLog_LimitsLines(t *testing.T) {
@@ -35,4 +44,15 @@ func TestTailLog_LimitsLines(t *testing.T) {
 	tail := tailLog(long, 100)
 	lines := strings.Count(tail, "\n")
 	assert.Equal(t, 100, lines)
+}
+
+func TestTailLog_Empty(t *testing.T) {
+	assert.Equal(t, "", tailLog("", 100))
+}
+
+func TestShellEscape_RejectsNewlineByQuoting(t *testing.T) {
+	// shellEscape treats \n / \r as escape-triggers (defense in depth).
+	out := shellEscape("foo\nbar")
+	assert.True(t, strings.HasPrefix(out, "'") && strings.HasSuffix(out, "'"),
+		"newline should force quoting: got %q", out)
 }

--- a/pkg/provision/install/install.go
+++ b/pkg/provision/install/install.go
@@ -1,0 +1,48 @@
+// Package install ships Oracle install primitives — runInstaller,
+// root.sh, asmca, netca, oracleasm/afd disk labeling — invoked by
+// /lab-up Phase D skills via dbxcli provision install <action>.
+//
+// All functions in this package require Enterprise license tier
+// (license.RequireTier checked at the cobra layer, not here).
+//
+// # Idempotency patterns
+//
+// Two patterns are used across this package depending on whether the
+// underlying Oracle command is itself idempotent. Tasks 4-8 add new
+// primitives and MUST pick the correct pattern.
+//
+// ## Touchfile (single-file) — for IDEMPOTENT operations only
+//
+// Used by RootSh. Oracle's root.sh is documented as safe to re-run, so
+// a single sentinel touchfile is written by the same shell pipeline as
+// the script itself ("script && touch <file>"). Any failure mode short
+// of "script ran cleanly" leaves the touchfile absent, and a re-run
+// simply re-invokes the script.
+//
+// This pattern is INSUFFICIENT for non-idempotent commands: if the
+// remote process completes the install but the local exec connection
+// drops before "touch" runs, the next invocation has no way to
+// distinguish "never ran" from "ran but wasn't recorded" — and
+// re-invoking runInstaller / asmca / dbca on a half-installed home
+// can corrupt the inventory.
+//
+// ## Two-phase sentinel (.partial → .installed) — for NON-IDEMPOTENT operations
+//
+// Required for runInstaller, asmca, dbca, and any other primitive
+// where re-running on a partially-completed prior run is unsafe. The
+// pattern is:
+//
+//  1. BEFORE invoking the install command, write <home>/.dbx/<op>.partial.
+//  2. AFTER the command exits 0, atomically rename <op>.partial →
+//     <op>.installed (mv, NOT a second touch — rename is atomic on a
+//     single filesystem; touch is not).
+//  3. Detection: <op>.installed present → DetectionStateInstalled;
+//     <op>.partial present without <op>.installed → DetectionStatePartial
+//     (operator must run the matching reverter before retrying);
+//     neither present → DetectionStateAbsent.
+//
+// The .partial sentinel intentionally outlives the running process so
+// that a hung or killed installer is observable on the next probe.
+// Tasks 4-8 implementing runInstaller / asmca / dbca MUST follow this
+// shape; do not reach for the touchfile pattern as a shortcut.
+package install

--- a/pkg/provision/install/netca.go
+++ b/pkg/provision/install/netca.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/otel"
 )
 
 // netcaSentinelDir is the directory under OracleBase where dbx writes the
@@ -38,7 +39,15 @@ func NetcaSilent(ctx context.Context, spec NetcaSpec, reset bool) (*InstallResul
 
 // netcaSilentWithExec is the testable core. Takes an injected executor so
 // unit tests can use hosttest.MockExecutor.
-func netcaSilentWithExec(ctx context.Context, exec host.Executor, spec NetcaSpec, reset bool) (*InstallResult, error) {
+func netcaSilentWithExec(ctx context.Context, exec host.Executor, spec NetcaSpec, reset bool) (res *InstallResult, retErr error) {
+	sb := otel.NewSpan("provision.install.netca", "dbxcli").
+		WithAttrs(
+			otel.StringAttr(otel.AttrDbxHost, spec.Target),
+			otel.StringAttr(otel.AttrDbxEntityType, "oracle_listener"),
+			otel.StringAttr(otel.AttrDbxEntityName, spec.ListenerName),
+		)
+	defer func() { emitSpan(ctx, sb, retErr) }()
+
 	if err := spec.Validate(); err != nil {
 		return nil, err
 	}
@@ -54,7 +63,7 @@ func netcaSilentWithExec(ctx context.Context, exec host.Executor, spec NetcaSpec
 		return nil, fmt.Errorf("install: detect netca state on %s: %w", spec.Target, err)
 	}
 
-	res := &InstallResult{Detected: state}
+	res = &InstallResult{Detected: state}
 
 	switch state {
 	case DetectionStateInstalled:

--- a/pkg/provision/install/netca.go
+++ b/pkg/provision/install/netca.go
@@ -1,0 +1,213 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/itunified-io/dbx/pkg/host"
+)
+
+// netcaSentinelDir is the directory under OracleBase where dbx writes the
+// two-phase sentinel files for netca. Per package godoc, this is the
+// canonical location for non-idempotent install primitives.
+const netcaSentinelDir = "/cfgtoollogs/dbx"
+
+// NetcaSilent creates an Oracle listener via `netca -silent`. Used during
+// Phase D.2 (after Grid + before DBCA) to ensure a LISTENER exists for
+// client connections AND during Phase E.2 to add static services
+// (e.g. ORCLSTB_DGMGRL) on the standby for RMAN DUPLICATE FROM ACTIVE.
+//
+// Idempotency: NON-IDEMPOTENT primitive — uses the two-phase sentinel
+// pattern documented in the install package godoc. Detection is
+// version-agnostic (file existence + an `lsnrctl status` live probe;
+// no version-string match against stdout).
+//
+// Reset semantics (MVP): --reset on Installed/Partial state prints a
+// manual runbook to stderr and returns Skipped. Destructive listener
+// drop is deferred to a reverter follow-up plan; this primitive does
+// NOT delete listeners.
+func NetcaSilent(ctx context.Context, spec NetcaSpec, reset bool) (*InstallResult, error) {
+	exec, err := newSSHExecutor(ctx, spec.Target)
+	if err != nil {
+		return nil, fmt.Errorf("install: ssh to %s: %w", spec.Target, err)
+	}
+	return netcaSilentWithExec(ctx, exec, spec, reset)
+}
+
+// netcaSilentWithExec is the testable core. Takes an injected executor so
+// unit tests can use hosttest.MockExecutor.
+func netcaSilentWithExec(ctx context.Context, exec host.Executor, spec NetcaSpec, reset bool) (*InstallResult, error) {
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+
+	if strings.TrimSpace(spec.ResponseFilePath) == "" {
+		return nil, fmt.Errorf("install: response_file_path required (caller must render + scp the netca .rsp first)")
+	}
+
+	partialPath, installedPath := netcaSentinelPaths(spec)
+
+	state, err := detectNetcaState(ctx, exec, spec.ListenerName, partialPath, installedPath)
+	if err != nil {
+		return nil, fmt.Errorf("install: detect netca state on %s: %w", spec.Target, err)
+	}
+
+	res := &InstallResult{Detected: state}
+
+	switch state {
+	case DetectionStateInstalled:
+		if !reset {
+			res.Skipped = true
+			return res, nil
+		}
+		fmt.Fprint(os.Stderr, netcaResetRunbook(spec, "installed", installedPath))
+		res.Skipped = true
+		return res, nil
+	case DetectionStatePartial:
+		if !reset {
+			return res, fmt.Errorf("install: partial netca state on %s (sentinel %s present without %s); rerun with --reset to print recovery runbook", spec.Target, partialPath, installedPath)
+		}
+		fmt.Fprint(os.Stderr, netcaResetRunbook(spec, "partial", partialPath))
+		res.Skipped = true
+		return res, nil
+	case DetectionStateAbsent:
+		// fall through
+	}
+
+	// Phase 1: write .partial sentinel BEFORE invoking netca.
+	mkdirCmd := fmt.Sprintf("mkdir -p %s && : > %s",
+		shellEscape(netcaSentinelRoot(spec)),
+		shellEscape(partialPath),
+	)
+	if _, err := exec.Run(ctx, mkdirCmd); err != nil {
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("install: netca sentinel-write interrupted (ctx %v) on %s: %w", ctx.Err(), spec.Target, err)
+		}
+		return nil, fmt.Errorf("install: write netca .partial sentinel on %s: %w", spec.Target, err)
+	}
+
+	// Phase 2: invoke netca -silent -responseFile <path>.
+	cmd := fmt.Sprintf("%s/bin/netca -silent -responseFile %s",
+		shellEscape(spec.OracleHome),
+		shellEscape(spec.ResponseFilePath),
+	)
+	runRes, err := exec.Run(ctx, cmd)
+	if err != nil {
+		// Local context cancelled mid-run: remote process may still be
+		// running. .partial sentinel persists so next probe sees Partial.
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("install: netca interrupted (ctx %v); remote process may still be running on %s; next run will see partial state: %w", ctx.Err(), spec.Target, err)
+		}
+		return nil, fmt.Errorf("install: netca transport failure on %s: %w", spec.Target, err)
+	}
+	res.ExitCode = runRes.ExitCode
+	res.LogTail = tailLog(runRes.Stdout+runRes.Stderr, 100)
+	if runRes.ExitCode != 0 {
+		// Non-zero exit: leave .partial in place so operator runs reverter.
+		res.Detected = DetectionStatePartial
+		return res, fmt.Errorf("install: netca exit %d on %s", runRes.ExitCode, spec.Target)
+	}
+
+	// Phase 3: atomic rename .partial → .installed.
+	mvCmd := fmt.Sprintf("mv %s %s", shellEscape(partialPath), shellEscape(installedPath))
+	if _, err := exec.Run(ctx, mvCmd); err != nil {
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("install: netca sentinel-rename interrupted (ctx %v) on %s: %w", ctx.Err(), spec.Target, err)
+		}
+		return nil, fmt.Errorf("install: rename netca sentinel on %s: %w", spec.Target, err)
+	}
+	res.Detected = DetectionStateInstalled
+	return res, nil
+}
+
+// detectNetcaState reads the two-phase sentinel pair PLUS a live
+// `lsnrctl status <name>` probe. The live probe is included so a
+// pre-existing listener (created outside dbx) is recognised as Installed
+// without forcing the operator to fabricate a sentinel file.
+//
+//	.installed sentinel present              → Installed
+//	lsnrctl status returns "STATUS of the LISTENER" → Installed
+//	.partial present without .installed      → Partial
+//	none of the above                        → Absent
+//
+// The lsnrctl probe is version-agnostic: it matches the static substring
+// "STATUS of the LISTENER" present in 11g..23ai output, never a version
+// number.
+func detectNetcaState(ctx context.Context, exec host.Executor, listenerName, partialPath, installedPath string) (DetectionState, error) {
+	hasInstalled, err := probeFile(ctx, exec, installedPath)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if hasInstalled {
+		return DetectionStateInstalled, nil
+	}
+	// Live probe — a listener may exist from a prior provisioning run that
+	// did not record a dbx sentinel (e.g. earlier dbx version, or manual
+	// netca invocation). Treat that as Installed to avoid double-create.
+	live, err := exec.Run(ctx, "lsnrctl status "+shellEscape(listenerName))
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if live.ExitCode == 0 && strings.Contains(live.Stdout, "STATUS of the LISTENER") {
+		return DetectionStateInstalled, nil
+	}
+	hasPartial, err := probeFile(ctx, exec, partialPath)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if hasPartial {
+		return DetectionStatePartial, nil
+	}
+	return DetectionStateAbsent, nil
+}
+
+// netcaSentinelRoot returns the directory under OracleBase that holds
+// dbx sentinel files for this primitive.
+func netcaSentinelRoot(spec NetcaSpec) string {
+	return spec.OracleBase + netcaSentinelDir
+}
+
+// netcaSentinelPaths returns (partialPath, installedPath) keyed on the
+// listener name (uppercased) so multiple listeners on the same host
+// don't collide.
+func netcaSentinelPaths(spec NetcaSpec) (string, string) {
+	root := netcaSentinelRoot(spec)
+	ln := strings.ToUpper(spec.ListenerName)
+	return root + "/netca." + ln + ".partial",
+		root + "/netca." + ln + ".installed"
+}
+
+// netcaResetRunbook returns a manual recovery runbook string that the
+// caller prints to stderr when --reset is invoked. The MVP does NOT
+// drop the listener; the operator must do that themselves.
+func netcaResetRunbook(spec NetcaSpec, state, sentinelPath string) string {
+	return fmt.Sprintf(`# netca --reset (MANUAL RUNBOOK; non-destructive in MVP)
+#
+# State on %s: %s
+# Sentinel:   %s
+# Listener:   %s (port %d)
+#
+# This primitive will NOT drop the listener automatically.
+# Manual recovery procedure:
+#
+#   1. Confirm no clients depend on the listener:
+#        lsnrctl services %s
+#
+#   2. (Operator) stop + drop the listener:
+#        lsnrctl stop %s
+#        # remove its entry from $ORACLE_HOME/network/admin/listener.ora
+#        # (or run netca -silent -deleteListener)
+#
+#   3. Remove the dbx sentinel:
+#        rm -f %s
+#
+#   4. Re-run dbxcli provision install netca (without --reset).
+#
+`, spec.Target, state, sentinelPath, spec.ListenerName, spec.Port,
+		spec.ListenerName, spec.ListenerName, sentinelPath)
+}

--- a/pkg/provision/install/netca.go
+++ b/pkg/provision/install/netca.go
@@ -49,7 +49,7 @@ func netcaSilentWithExec(ctx context.Context, exec host.Executor, spec NetcaSpec
 
 	partialPath, installedPath := netcaSentinelPaths(spec)
 
-	state, err := detectNetcaState(ctx, exec, spec.ListenerName, partialPath, installedPath)
+	state, err := detectNetcaState(ctx, exec, spec.OracleHome, spec.ListenerName, partialPath, installedPath)
 	if err != nil {
 		return nil, fmt.Errorf("install: detect netca state on %s: %w", spec.Target, err)
 	}
@@ -138,7 +138,7 @@ func netcaSilentWithExec(ctx context.Context, exec host.Executor, spec NetcaSpec
 // The lsnrctl probe is version-agnostic: it matches the static substring
 // "STATUS of the LISTENER" present in 11g..23ai output, never a version
 // number.
-func detectNetcaState(ctx context.Context, exec host.Executor, listenerName, partialPath, installedPath string) (DetectionState, error) {
+func detectNetcaState(ctx context.Context, exec host.Executor, oracleHome, listenerName, partialPath, installedPath string) (DetectionState, error) {
 	hasInstalled, err := probeFile(ctx, exec, installedPath)
 	if err != nil {
 		return DetectionStateAbsent, err
@@ -149,7 +149,17 @@ func detectNetcaState(ctx context.Context, exec host.Executor, listenerName, par
 	// Live probe — a listener may exist from a prior provisioning run that
 	// did not record a dbx sentinel (e.g. earlier dbx version, or manual
 	// netca invocation). Treat that as Installed to avoid double-create.
-	live, err := exec.Run(ctx, "lsnrctl status "+shellEscape(listenerName))
+	//
+	// Qualify lsnrctl with $ORACLE_HOME and the absolute binary path:
+	// non-interactive SSH sessions on Grid Infrastructure hosts do NOT
+	// have $ORACLE_HOME/bin on $PATH, so a bare `lsnrctl` would fail with
+	// "command not found" and the probe would mis-report Absent.
+	probeCmd := fmt.Sprintf("env ORACLE_HOME=%s %s/bin/lsnrctl status %s",
+		shellEscape(oracleHome),
+		shellEscape(oracleHome),
+		shellEscape(listenerName),
+	)
+	live, err := exec.Run(ctx, probeCmd)
 	if err != nil {
 		return DetectionStateAbsent, err
 	}

--- a/pkg/provision/install/netca_test.go
+++ b/pkg/provision/install/netca_test.go
@@ -1,0 +1,319 @@
+package install
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/host/hosttest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validNetcaSpec returns a minimal valid spec usable across tests.
+func validNetcaSpec() NetcaSpec {
+	return NetcaSpec{
+		InstallSpec: InstallSpec{
+			Target:           "ext3adm1",
+			OracleHome:       "/u01/app/oracle/product/19c/dbhome_1",
+			OracleBase:       "/u01/app/oracle",
+			ResponseFilePath: "/tmp/netca.rsp",
+		},
+		ListenerName: "LISTENER",
+		Port:         1521,
+	}
+}
+
+func TestNetcaSilent(t *testing.T) {
+	const partial = "/u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.partial"
+	const installed = "/u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.installed"
+	const lsnrctl = "lsnrctl status LISTENER"
+	const mkdir = "mkdir -p /u01/app/oracle/cfgtoollogs/dbx && : > /u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.partial"
+	const netca = "/u01/app/oracle/product/19c/dbhome_1/bin/netca -silent -responseFile /tmp/netca.rsp"
+	const mv = "mv /u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.partial /u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.installed"
+
+	const lsnrctlOk = "LSNRCTL for Linux: Version 19.0.0.0.0\n\nSTATUS of the LISTENER\n------------------------\nAlias                     LISTENER\n"
+	const lsnrctlAbsent = "TNS-12541: TNS:no listener\n"
+
+	cases := []struct {
+		name            string
+		setupMock       func(*hosttest.MockExecutor)
+		spec            NetcaSpec
+		reset           bool
+		wantErr         string
+		wantSkipped     bool
+		wantDetected    DetectionState
+		wantLogContains string
+	}{
+		{
+			name: "InstalledSentinelDetected_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(0, "", "")
+			},
+			spec:         validNetcaSpec(),
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "LiveListenerDetected_NoSentinel_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(lsnrctl).Returns(0, lsnrctlOk, "")
+			},
+			spec:         validNetcaSpec(),
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "PartialSentinelDetected_ReturnsError",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(lsnrctl).Returns(1, lsnrctlAbsent, "")
+				m.OnCommand("test -f " + partial).Returns(0, "", "")
+			},
+			spec:         validNetcaSpec(),
+			wantErr:      "partial netca state",
+			wantDetected: DetectionStatePartial,
+		},
+		{
+			name: "AbsentListener_RunsFullPipeline",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(lsnrctl).Returns(1, lsnrctlAbsent, "")
+				m.OnCommand("test -f " + partial).Returns(1, "", "")
+				m.OnCommand(mkdir).Returns(0, "", "")
+				m.OnCommand(netca).Returns(0, "Oracle Net Listener Startup:\nLISTENER successfully started.\n", "")
+				m.OnCommand(mv).Returns(0, "", "")
+			},
+			spec:            validNetcaSpec(),
+			wantSkipped:     false,
+			wantDetected:    DetectionStateInstalled,
+			wantLogContains: "successfully started",
+		},
+		{
+			name: "NetcaExitNonzero_LeavesPartialAndErrors",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(lsnrctl).Returns(1, lsnrctlAbsent, "")
+				m.OnCommand("test -f " + partial).Returns(1, "", "")
+				m.OnCommand(mkdir).Returns(0, "", "")
+				m.OnCommand(netca).Returns(2, "TNS-04404: response file not found\n", "")
+			},
+			spec:            validNetcaSpec(),
+			wantErr:         "exit 2",
+			wantDetected:    DetectionStatePartial,
+			wantLogContains: "TNS-04404",
+		},
+		{
+			name: "Reset_OnInstalled_PrintsRunbook_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(0, "", "")
+			},
+			spec:         validNetcaSpec(),
+			reset:        true,
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "Reset_OnPartial_PrintsRunbook_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(lsnrctl).Returns(1, lsnrctlAbsent, "")
+				m.OnCommand("test -f " + partial).Returns(0, "", "")
+			},
+			spec:         validNetcaSpec(),
+			reset:        true,
+			wantSkipped:  true,
+			wantDetected: DetectionStatePartial,
+		},
+		{
+			name:      "RejectsMissingResponseFile",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: func() NetcaSpec {
+				s := validNetcaSpec()
+				s.ResponseFilePath = ""
+				return s
+			}(),
+			wantErr:      "response_file_path required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsMissingTarget",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: NetcaSpec{
+				InstallSpec:  InstallSpec{OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				ListenerName: "L", Port: 1521,
+			},
+			wantErr:      "target is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsMissingOracleBase",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: NetcaSpec{
+				InstallSpec:  InstallSpec{Target: "x", OracleHome: "/x", ResponseFilePath: "/r"},
+				ListenerName: "L", Port: 1521,
+			},
+			wantErr:      "oracle_base is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsMissingListenerName",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: NetcaSpec{
+				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				Port:        1521,
+			},
+			wantErr:      "listener_name is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsListenerNameWithShellMetachar_Semicolon",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: NetcaSpec{
+				InstallSpec:  InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				ListenerName: "LISTENER;rm -rf /", Port: 1521,
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsListenerNameWithBacktick",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: NetcaSpec{
+				InstallSpec:  InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				ListenerName: "L`whoami`", Port: 1521,
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsListenerNameWithDollar",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: NetcaSpec{
+				InstallSpec:  InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				ListenerName: "L$(id)", Port: 1521,
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsListenerNameWithSpace",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: NetcaSpec{
+				InstallSpec:  InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				ListenerName: "MY LISTENER", Port: 1521,
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsTargetWithNewline",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: NetcaSpec{
+				InstallSpec:  InstallSpec{Target: "x\nrm -rf /", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				ListenerName: "L", Port: 1521,
+			},
+			wantErr:      "control character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsPortZero",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: NetcaSpec{
+				InstallSpec:  InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				ListenerName: "L", Port: 0,
+			},
+			wantErr:      "port must be",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsPortOutOfRange",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: NetcaSpec{
+				InstallSpec:  InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y", ResponseFilePath: "/r"},
+				ListenerName: "L", Port: 99999,
+			},
+			wantErr:      "port must be",
+			wantDetected: DetectionStateUnset,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := hosttest.NewMockExecutor()
+			tc.setupMock(mock)
+			res, err := netcaSilentWithExec(context.Background(), mock, tc.spec, tc.reset)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				if tc.wantLogContains != "" && res != nil {
+					assert.Contains(t, res.LogTail, tc.wantLogContains)
+				}
+				if tc.wantDetected != DetectionStateUnset && res != nil {
+					assert.Equal(t, tc.wantDetected, res.Detected)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			assert.Equal(t, tc.wantSkipped, res.Skipped)
+			assert.Equal(t, tc.wantDetected, res.Detected)
+			if tc.wantLogContains != "" {
+				assert.Contains(t, res.LogTail, tc.wantLogContains)
+			}
+		})
+	}
+}
+
+// netcaCtxCancelExec mimics asmca_test.go's helper: lets the first N probe
+// calls go to the inner mock, then cancels ctx and fails the (N+1)-th
+// call to simulate a transport disconnect mid-run.
+type netcaCtxCancelExec struct {
+	inner       host.Executor
+	cancelAfter int
+	calls       int
+	cancel      context.CancelFunc
+	wrapErr     error
+}
+
+func (e *netcaCtxCancelExec) Run(ctx context.Context, cmd string) (*host.RunResult, error) {
+	e.calls++
+	if e.calls <= e.cancelAfter {
+		return e.inner.Run(ctx, cmd)
+	}
+	if e.cancel != nil {
+		e.cancel()
+	}
+	return nil, e.wrapErr
+}
+
+func TestNetcaSilent_CtxCancelled_ReportsPartial(t *testing.T) {
+	const partial = "/u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.partial"
+	const installed = "/u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.installed"
+	const lsnrctl = "lsnrctl status LISTENER"
+	const mkdir = "mkdir -p /u01/app/oracle/cfgtoollogs/dbx && : > /u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.partial"
+
+	mock := hosttest.NewMockExecutor()
+	mock.OnCommand("test -f " + installed).Returns(1, "", "")
+	mock.OnCommand(lsnrctl).Returns(1, "TNS-12541: TNS:no listener\n", "")
+	mock.OnCommand("test -f " + partial).Returns(1, "", "")
+	mock.OnCommand(mkdir).Returns(0, "", "")
+	// netca call is intercepted and ctx-cancelled by the wrapper.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ex := &netcaCtxCancelExec{
+		inner:       mock,
+		cancelAfter: 4, // 3 probes (installed, lsnrctl, partial) + 1 sentinel-write
+		cancel:      cancel,
+		wrapErr:     errors.New("transport: connection closed"),
+	}
+
+	res, err := netcaSilentWithExec(ctx, ex, validNetcaSpec(), false)
+	require.Error(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, DetectionStatePartial, res.Detected)
+	assert.Contains(t, err.Error(), "interrupted")
+	assert.Contains(t, err.Error(), "may still be running")
+}

--- a/pkg/provision/install/netca_test.go
+++ b/pkg/provision/install/netca_test.go
@@ -28,7 +28,7 @@ func validNetcaSpec() NetcaSpec {
 func TestNetcaSilent(t *testing.T) {
 	const partial = "/u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.partial"
 	const installed = "/u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.installed"
-	const lsnrctl = "lsnrctl status LISTENER"
+	const lsnrctl = "env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/lsnrctl status LISTENER"
 	const mkdir = "mkdir -p /u01/app/oracle/cfgtoollogs/dbx && : > /u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.partial"
 	const netca = "/u01/app/oracle/product/19c/dbhome_1/bin/netca -silent -responseFile /tmp/netca.rsp"
 	const mv = "mv /u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.partial /u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.installed"
@@ -292,7 +292,7 @@ func (e *netcaCtxCancelExec) Run(ctx context.Context, cmd string) (*host.RunResu
 func TestNetcaSilent_CtxCancelled_ReportsPartial(t *testing.T) {
 	const partial = "/u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.partial"
 	const installed = "/u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.installed"
-	const lsnrctl = "lsnrctl status LISTENER"
+	const lsnrctl = "env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/lsnrctl status LISTENER"
 	const mkdir = "mkdir -p /u01/app/oracle/cfgtoollogs/dbx && : > /u01/app/oracle/cfgtoollogs/dbx/netca.LISTENER.partial"
 
 	mock := hosttest.NewMockExecutor()

--- a/pkg/provision/install/otel.go
+++ b/pkg/provision/install/otel.go
@@ -1,0 +1,29 @@
+package install
+
+import (
+	"context"
+
+	"github.com/itunified-io/dbx/pkg/otel"
+)
+
+// emitSpan exports a single span via the package-level OTEL exporter.
+// Pattern (used in every *WithExec primitive):
+//
+//	defer func() { emitSpan(ctx, sb, retErr) }()
+//
+// Best-effort: NoopExporter (the default) makes this a no-op when no
+// OTEL endpoint is configured. Errors from Export are intentionally
+// swallowed — the signed JSONL audit chain (ADR-0095) is the canonical
+// record; OTEL is the observability mirror per ADR-0103a.
+func emitSpan(ctx context.Context, sb *otel.SpanBuilder, retErr error) {
+	if sb == nil {
+		return
+	}
+	var span otel.Span
+	if retErr != nil {
+		span = sb.EndError(retErr)
+	} else {
+		span = sb.EndOK()
+	}
+	_ = otel.GlobalExporter().Export(ctx, []otel.Span{span})
+}

--- a/pkg/provision/install/otel_test.go
+++ b/pkg/provision/install/otel_test.go
@@ -1,0 +1,180 @@
+package install
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/itunified-io/dbx/pkg/host/hosttest"
+	"github.com/itunified-io/dbx/pkg/otel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureExporter is a tiny in-test Exporter that retains every
+// exported span for assertion. Concurrency-safe so deferred Export()
+// from primitives racing with the test is fine.
+type captureExporter struct {
+	mu    sync.Mutex
+	spans []otel.Span
+}
+
+func (e *captureExporter) Export(_ context.Context, spans []otel.Span) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.spans = append(e.spans, spans...)
+	return nil
+}
+
+func (e *captureExporter) Shutdown(_ context.Context) error { return nil }
+
+func (e *captureExporter) Snapshot() []otel.Span {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]otel.Span, len(e.spans))
+	copy(out, e.spans)
+	return out
+}
+
+// withCaptureExporter installs a fresh capture exporter for the duration
+// of a test, restoring the prior exporter on cleanup.
+func withCaptureExporter(t *testing.T) *captureExporter {
+	t.Helper()
+	prev := otel.GlobalExporter()
+	cap := &captureExporter{}
+	otel.SetGlobalExporter(cap)
+	t.Cleanup(func() { otel.SetGlobalExporter(prev) })
+	return cap
+}
+
+// TestInstallPrimitives_EmitOTELSpan verifies each of the 8 install
+// primitives emits exactly one OTEL span with the expected name +
+// status + dbx.* attributes when invoked through the *WithExec test
+// seam. Happy-path table covers the StatusOK case; the
+// "MalformedSpec_StatusError" subtest covers StatusError.
+func TestInstallPrimitives_EmitOTELSpan(t *testing.T) {
+	t.Run("Grid_HappyPath", func(t *testing.T) {
+		cap := withCaptureExporter(t)
+		mock := hosttest.NewMockExecutor()
+		mock.OnCommand("test -f /etc/oraInst.loc").Returns(0, "x\n", "")
+		mock.OnCommand("test -d /u01/app/19c/grid/inventory && ls -A /u01/app/19c/grid/inventory | head -1").
+			Returns(0, "ContentsXML\n", "")
+		_, err := gridInstallWithExec(context.Background(), mock,
+			InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/grid", OracleBase: "/u01/app/grid"},
+			false)
+		require.NoError(t, err)
+		assertOneSpan(t, cap, "provision.install.grid", otel.StatusOK, map[string]string{
+			otel.AttrDbxHost:       "ext3adm1",
+			otel.AttrDbxEntityType: "oracle_grid_home",
+			otel.AttrDbxEntityName: "/u01/app/19c/grid",
+		})
+	})
+
+	t.Run("Grid_ValidateError_StatusError", func(t *testing.T) {
+		cap := withCaptureExporter(t)
+		mock := hosttest.NewMockExecutor()
+		_, err := gridInstallWithExec(context.Background(), mock, InstallSpec{}, false)
+		require.Error(t, err)
+		spans := cap.Snapshot()
+		require.Len(t, spans, 1)
+		assert.Equal(t, "provision.install.grid", spans[0].Name)
+		assert.Equal(t, otel.StatusError, spans[0].Status)
+	})
+
+	t.Run("DBHome_HappyPath", func(t *testing.T) {
+		cap := withCaptureExporter(t)
+		mock := hosttest.NewMockExecutor()
+		mock.OnCommand("/u01/app/19c/dbhome_1/bin/oracle -V 2>&1 | head -1").Returns(0, "Oracle Database 19c\n", "")
+		mock.OnCommand("/u01/app/19c/dbhome_1/OPatch/opatch lsinventory 2>&1 | head -5").Returns(0, "Installed Top-level Products\n", "")
+		_, err := dbhomeInstallWithExec(context.Background(), mock,
+			InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/dbhome_1", OracleBase: "/u01/app/oracle"},
+			false)
+		require.NoError(t, err)
+		assertOneSpan(t, cap, "provision.install.dbhome", otel.StatusOK, map[string]string{
+			otel.AttrDbxEntityType: "oracle_db_home",
+		})
+	})
+
+	t.Run("RootSh_HappyPath_AlreadyDone", func(t *testing.T) {
+		cap := withCaptureExporter(t)
+		mock := hosttest.NewMockExecutor()
+		mock.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile").Returns(0, "", "")
+		_, err := rootShWithExec(context.Background(), mock,
+			InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/grid"},
+			false)
+		require.NoError(t, err)
+		assertOneSpan(t, cap, "provision.install.root_sh", otel.StatusOK, map[string]string{
+			otel.AttrDbxEntityType: "oracle_root_sh",
+		})
+	})
+
+	t.Run("Asmca_ValidateError_StatusError", func(t *testing.T) {
+		cap := withCaptureExporter(t)
+		mock := hosttest.NewMockExecutor()
+		_, err := asmcaSilentWithExec(context.Background(), mock, AsmcaSpec{}, false)
+		require.Error(t, err)
+		spans := cap.Snapshot()
+		require.Len(t, spans, 1)
+		assert.Equal(t, "provision.install.asmca", spans[0].Name)
+		assert.Equal(t, otel.StatusError, spans[0].Status)
+	})
+
+	t.Run("Netca_ValidateError_StatusError", func(t *testing.T) {
+		cap := withCaptureExporter(t)
+		mock := hosttest.NewMockExecutor()
+		_, err := netcaSilentWithExec(context.Background(), mock, NetcaSpec{}, false)
+		require.Error(t, err)
+		spans := cap.Snapshot()
+		require.Len(t, spans, 1)
+		assert.Equal(t, "provision.install.netca", spans[0].Name)
+		assert.Equal(t, otel.StatusError, spans[0].Status)
+	})
+
+	t.Run("AsmLabel_ValidateError_StatusError", func(t *testing.T) {
+		cap := withCaptureExporter(t)
+		mock := hosttest.NewMockExecutor()
+		_, err := asmDiskLabelWithExec(context.Background(), mock, AsmDiskLabelSpec{}, false)
+		require.Error(t, err)
+		spans := cap.Snapshot()
+		require.Len(t, spans, 1)
+		assert.Equal(t, "provision.install.asm_label", spans[0].Name)
+		assert.Equal(t, otel.StatusError, spans[0].Status)
+	})
+
+	t.Run("Dbca_ValidateError_StatusError", func(t *testing.T) {
+		cap := withCaptureExporter(t)
+		mock := hosttest.NewMockExecutor()
+		_, err := dbcaCreateDbWithExec(context.Background(), mock, DbcaCreateDbSpec{}, false)
+		require.Error(t, err)
+		spans := cap.Snapshot()
+		require.Len(t, spans, 1)
+		assert.Equal(t, "provision.install.dbca_create_db", spans[0].Name)
+		assert.Equal(t, otel.StatusError, spans[0].Status)
+	})
+
+	t.Run("Pdb_ValidateError_StatusError", func(t *testing.T) {
+		cap := withCaptureExporter(t)
+		mock := hosttest.NewMockExecutor()
+		_, err := pdbCreateWithExec(context.Background(), mock, PdbCreateSpec{}, false)
+		require.Error(t, err)
+		spans := cap.Snapshot()
+		require.Len(t, spans, 1)
+		assert.Equal(t, "provision.install.pdb_create", spans[0].Name)
+		assert.Equal(t, otel.StatusError, spans[0].Status)
+	})
+}
+
+// assertOneSpan asserts the capture exporter saw exactly one span with
+// the given name and status, and that every (key, value) in wantAttrs
+// is present on the span's attribute map.
+func assertOneSpan(t *testing.T, cap *captureExporter, wantName string, wantStatus otel.Status, wantAttrs map[string]string) {
+	t.Helper()
+	spans := cap.Snapshot()
+	require.Len(t, spans, 1, "expected exactly one span")
+	assert.Equal(t, wantName, spans[0].Name)
+	assert.Equal(t, wantStatus, spans[0].Status)
+	got := spans[0].AttributeMap()
+	for k, v := range wantAttrs {
+		assert.Equal(t, v, got[k], "attribute %s mismatch", k)
+	}
+}

--- a/pkg/provision/install/pdb.go
+++ b/pkg/provision/install/pdb.go
@@ -1,0 +1,254 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/itunified-io/dbx/pkg/host"
+)
+
+// PdbCreate creates an Oracle Pluggable Database via
+// `dbca -silent -createPluggableDatabase`. Phase D.5 of /lab-up —
+// runs after the parent CDB exists (Phase D.4 dbca -createDatabase).
+//
+// Idempotency: NON-IDEMPOTENT primitive — uses the two-phase sentinel
+// pattern documented in the install package godoc, keyed on
+// (parent CDB, new PDB) so same-PDB-name in different CDBs on the
+// same host does not collide.
+//
+// Detection probes the .installed sentinel first, then falls back to
+// a sqlplus query against v$pdbs. Detection is version-agnostic:
+// only the binary exit code is consulted, never a substring match
+// against stdout.
+//
+// Reset semantics (MVP): --reset on Installed/Partial state prints a
+// manual runbook to stderr and returns Skipped. Destructive
+// `dbca -silent -deletePluggableDatabase` is deferred to a reverter
+// follow-up plan; this primitive does NOT drop PDBs.
+func PdbCreate(ctx context.Context, spec PdbCreateSpec, reset bool) (*InstallResult, error) {
+	exec, err := newSSHExecutor(ctx, spec.Target)
+	if err != nil {
+		return nil, fmt.Errorf("install: ssh to %s: %w", spec.Target, err)
+	}
+	return pdbCreateWithExec(ctx, exec, spec, reset)
+}
+
+// pdbCreateWithExec is the testable core. Takes an injected executor
+// so unit tests can use hosttest.MockExecutor.
+func pdbCreateWithExec(ctx context.Context, exec host.Executor, spec PdbCreateSpec, reset bool) (*InstallResult, error) {
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+
+	partialPath, installedPath := pdbSentinelPaths(spec)
+
+	state, err := detectPdbState(ctx, exec, spec.OracleHome, spec.PdbName, partialPath, installedPath)
+	if err != nil {
+		return nil, fmt.Errorf("install: detect pdb state on %s: %w", spec.Target, err)
+	}
+
+	res := &InstallResult{Detected: state}
+
+	switch state {
+	case DetectionStateInstalled:
+		if !reset {
+			res.Skipped = true
+			return res, nil
+		}
+		fmt.Fprint(os.Stderr, pdbResetRunbook(spec, "installed", installedPath))
+		res.Skipped = true
+		return res, nil
+	case DetectionStatePartial:
+		if !reset {
+			return res, fmt.Errorf("install: partial pdb state on %s (sentinel %s present without %s); rerun with --reset to print recovery runbook", spec.Target, partialPath, installedPath)
+		}
+		fmt.Fprint(os.Stderr, pdbResetRunbook(spec, "partial", partialPath))
+		res.Skipped = true
+		return res, nil
+	case DetectionStateAbsent:
+		// fall through
+	}
+
+	// Phase 1: write .partial sentinel BEFORE invoking dbca.
+	mkdirCmd := fmt.Sprintf("mkdir -p %s && : > %s",
+		shellEscape(pdbSentinelRoot(spec)),
+		shellEscape(partialPath),
+	)
+	if _, err := exec.Run(ctx, mkdirCmd); err != nil {
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("install: pdb sentinel-write interrupted (ctx %v); remote process may still be running on %s: %w", ctx.Err(), spec.Target, err)
+		}
+		return nil, fmt.Errorf("install: write pdb .partial sentinel on %s: %w", spec.Target, err)
+	}
+
+	// Phase 2: invoke dbca -silent -createPluggableDatabase.
+	// Qualify with $ORACLE_HOME and the absolute binary path: non-
+	// interactive SSH sessions on the oracle account do NOT have
+	// $ORACLE_HOME/bin on $PATH, so a bare `dbca` would fail with
+	// "command not found".
+	//
+	// Two CLI shapes are supported:
+	//   - response-file form (when ResponseFilePath != ""):
+	//       dbca -silent -createPluggableDatabase -responseFile <rsp>
+	//   - direct-CLI form (default):
+	//       dbca -silent -createPluggableDatabase -sourceDB <CDB>
+	//         -pdbName <PDB> -pdbAdminUserName PDBADMIN
+	//         -pdbAdminPasswordFile <file>
+	//         [-pdbDatafileDestination <dest>]
+	//
+	// Passwords are NEVER on the command line — dbca reads
+	// -pdbAdminPasswordFile from a 0600 file owned by the oracle user
+	// that the caller (skill) placed before invocation.
+	var dbcaCmd string
+	if spec.ResponseFilePath != "" {
+		dbcaCmd = fmt.Sprintf("env ORACLE_HOME=%s %s/bin/dbca -silent -createPluggableDatabase -responseFile %s",
+			shellEscape(spec.OracleHome),
+			shellEscape(spec.OracleHome),
+			shellEscape(spec.ResponseFilePath),
+		)
+	} else {
+		parts := []string{
+			fmt.Sprintf("env ORACLE_HOME=%s %s/bin/dbca -silent -createPluggableDatabase",
+				shellEscape(spec.OracleHome),
+				shellEscape(spec.OracleHome),
+			),
+			"-sourceDB " + shellEscape(spec.CdbName),
+			"-pdbName " + shellEscape(spec.PdbName),
+			"-pdbAdminUserName PDBADMIN",
+			"-pdbAdminPasswordFile " + shellEscape(spec.AdminPasswordFile),
+		}
+		if spec.DatafileDest != "" {
+			parts = append(parts, "-pdbDatafileDestination "+shellEscape(spec.DatafileDest))
+		}
+		dbcaCmd = strings.Join(parts, " ")
+	}
+	runRes, err := exec.Run(ctx, dbcaCmd)
+	if err != nil {
+		// Local context cancelled mid-run: remote process may still be
+		// running. .partial sentinel persists so next probe sees Partial.
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("install: dbca -createPluggableDatabase interrupted (ctx %v); remote process may still be running on %s; next run will see partial state: %w", ctx.Err(), spec.Target, err)
+		}
+		return nil, fmt.Errorf("install: dbca -createPluggableDatabase transport failure on %s: %w", spec.Target, err)
+	}
+	res.ExitCode = runRes.ExitCode
+	res.LogTail = tailLog(runRes.Stdout+runRes.Stderr, 100)
+	if runRes.ExitCode != 0 {
+		// Non-zero exit: leave .partial in place so operator runs reverter.
+		res.Detected = DetectionStatePartial
+		return res, fmt.Errorf("install: dbca -createPluggableDatabase exit %d on %s", runRes.ExitCode, spec.Target)
+	}
+
+	// Phase 3: atomic rename .partial → .installed.
+	mvCmd := fmt.Sprintf("mv %s %s", shellEscape(partialPath), shellEscape(installedPath))
+	if _, err := exec.Run(ctx, mvCmd); err != nil {
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("install: pdb sentinel-rename interrupted (ctx %v); remote process may still be running on %s: %w", ctx.Err(), spec.Target, err)
+		}
+		return nil, fmt.Errorf("install: rename pdb sentinel on %s: %w", spec.Target, err)
+	}
+	res.Detected = DetectionStateInstalled
+	return res, nil
+}
+
+// detectPdbState reads the two-phase sentinel pair PLUS a live
+// `sqlplus` probe against v$pdbs.
+//
+//	.installed sentinel present              → Installed
+//	sqlplus probe matches PDB row            → Installed
+//	.partial present without .installed      → Partial
+//	none of the above                        → Absent
+//
+// The sqlplus probe is version-agnostic: only the exit code AND
+// presence of the upper-cased PDB name in stdout are consulted. The
+// SQL is delivered via stdin heredoc (echo | sqlplus -s) — passing it
+// on the command line would expose the query in ps(1).
+func detectPdbState(ctx context.Context, exec host.Executor, oracleHome, pdbName, partialPath, installedPath string) (DetectionState, error) {
+	hasInstalled, err := probeFile(ctx, exec, installedPath)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if hasInstalled {
+		return DetectionStateInstalled, nil
+	}
+	// Live probe: select open_mode from v$pdbs where name = upper('<PDB>').
+	// Empty result (no row) → exit 0 with no PDB name in stdout → not Installed.
+	probeSQL := fmt.Sprintf("set heading off pagesize 0 feedback off; select name from v$pdbs where name = upper('%s'); exit;", pdbName)
+	probeCmd := fmt.Sprintf("echo %s | env ORACLE_HOME=%s %s/bin/sqlplus -s / as sysdba",
+		shellEscape(probeSQL),
+		shellEscape(oracleHome),
+		shellEscape(oracleHome),
+	)
+	live, err := exec.Run(ctx, probeCmd)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if live.ExitCode == 0 && strings.Contains(strings.ToUpper(live.Stdout), strings.ToUpper(pdbName)) {
+		return DetectionStateInstalled, nil
+	}
+	hasPartial, err := probeFile(ctx, exec, partialPath)
+	if err != nil {
+		return DetectionStateAbsent, err
+	}
+	if hasPartial {
+		return DetectionStatePartial, nil
+	}
+	return DetectionStateAbsent, nil
+}
+
+// pdbSentinelRoot returns the directory under OracleBase that holds
+// dbx sentinel files for this primitive.
+func pdbSentinelRoot(spec PdbCreateSpec) string {
+	// Reuse dbcaSentinelDir constant — same canonical location for all
+	// non-idempotent install primitives (per package godoc).
+	return spec.OracleBase + dbcaSentinelDir
+}
+
+// pdbSentinelPaths returns (partialPath, installedPath) keyed on the
+// parent CDB name + PDB name (both upper-cased) so multiple PDBs on
+// the same host across different CDBs don't collide.
+func pdbSentinelPaths(spec PdbCreateSpec) (string, string) {
+	root := pdbSentinelRoot(spec)
+	cdb := strings.ToUpper(spec.CdbName)
+	pdb := strings.ToUpper(spec.PdbName)
+	return root + "/pdb." + cdb + "." + pdb + ".partial",
+		root + "/pdb." + cdb + "." + pdb + ".installed"
+}
+
+// pdbResetRunbook returns a manual recovery runbook string. The MVP
+// does NOT drop the PDB; the operator must do that themselves via
+// `dbca -silent -deletePluggableDatabase`.
+func pdbResetRunbook(spec PdbCreateSpec, state, sentinelPath string) string {
+	return fmt.Sprintf(`# pdb create --reset (MANUAL RUNBOOK; non-destructive in MVP)
+#
+# State on %s: %s
+# Sentinel:   %s
+# Parent CDB: %s
+# PDB:        %s
+#
+# This primitive will NOT drop the PDB automatically.
+# Manual recovery procedure:
+#
+#   1. Confirm the PDB is closed and not in use:
+#        env ORACLE_HOME=%s %s/bin/sqlplus -s / as sysdba <<<'select name, open_mode from v$pdbs;'
+#
+#   2. (Operator) silently delete the PDB:
+#        env ORACLE_HOME=%s %s/bin/dbca -silent -deletePluggableDatabase \
+#          -sourceDB %s -pdbName %s
+#
+#   3. Remove the dbx sentinel:
+#        rm -f %s
+#
+#   4. Re-run dbxcli provision install pdb (without --reset).
+#
+`, spec.Target, state, sentinelPath, spec.CdbName, spec.PdbName,
+		spec.OracleHome, spec.OracleHome,
+		spec.OracleHome, spec.OracleHome,
+		spec.CdbName, spec.PdbName,
+		sentinelPath)
+}

--- a/pkg/provision/install/pdb.go
+++ b/pkg/provision/install/pdb.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/otel"
 )
 
 // PdbCreate creates an Oracle Pluggable Database via
@@ -37,7 +38,15 @@ func PdbCreate(ctx context.Context, spec PdbCreateSpec, reset bool) (*InstallRes
 
 // pdbCreateWithExec is the testable core. Takes an injected executor
 // so unit tests can use hosttest.MockExecutor.
-func pdbCreateWithExec(ctx context.Context, exec host.Executor, spec PdbCreateSpec, reset bool) (*InstallResult, error) {
+func pdbCreateWithExec(ctx context.Context, exec host.Executor, spec PdbCreateSpec, reset bool) (res *InstallResult, retErr error) {
+	sb := otel.NewSpan("provision.install.pdb_create", "dbxcli").
+		WithAttrs(
+			otel.StringAttr(otel.AttrDbxHost, spec.Target),
+			otel.StringAttr(otel.AttrDbxEntityType, "oracle_pdb"),
+			otel.StringAttr(otel.AttrDbxEntityName, spec.CdbName+"/"+spec.PdbName),
+		)
+	defer func() { emitSpan(ctx, sb, retErr) }()
+
 	if err := spec.Validate(); err != nil {
 		return nil, err
 	}
@@ -49,7 +58,7 @@ func pdbCreateWithExec(ctx context.Context, exec host.Executor, spec PdbCreateSp
 		return nil, fmt.Errorf("install: detect pdb state on %s: %w", spec.Target, err)
 	}
 
-	res := &InstallResult{Detected: state}
+	res = &InstallResult{Detected: state}
 
 	switch state {
 	case DetectionStateInstalled:

--- a/pkg/provision/install/pdb_test.go
+++ b/pkg/provision/install/pdb_test.go
@@ -1,0 +1,378 @@
+package install
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/host/hosttest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validPdbSpec returns a minimal valid spec usable across tests.
+func validPdbSpec() PdbCreateSpec {
+	return PdbCreateSpec{
+		InstallSpec: InstallSpec{
+			Target:     "ext3adm1",
+			OracleHome: "/u01/app/oracle/product/19c/dbhome_1",
+			OracleBase: "/u01/app/oracle",
+		},
+		CdbName:           "ORCL",
+		PdbName:           "PDB1",
+		AdminPasswordFile: "/tmp/pdbadmin.pw",
+	}
+}
+
+func TestPdbCreate(t *testing.T) {
+	const partial = "/u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.partial"
+	const installed = "/u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.installed"
+	// SQL probe is delivered via heredoc-style echo | sqlplus
+	const probeSQL = "set heading off pagesize 0 feedback off; select name from v$pdbs where name = upper('PDB1'); exit;"
+	probeCmd := "echo " + shellEscape(probeSQL) + " | env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/sqlplus -s / as sysdba"
+	const mkdir = "mkdir -p /u01/app/oracle/cfgtoollogs/dbx && : > /u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.partial"
+	const dbca = "env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/dbca -silent -createPluggableDatabase -sourceDB ORCL -pdbName PDB1 -pdbAdminUserName PDBADMIN -pdbAdminPasswordFile /tmp/pdbadmin.pw"
+	const mv = "mv /u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.partial /u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.installed"
+
+	cases := []struct {
+		name            string
+		setupMock       func(*hosttest.MockExecutor)
+		spec            PdbCreateSpec
+		reset           bool
+		wantErr         string
+		wantSkipped     bool
+		wantDetected    DetectionState
+		wantLogContains string
+	}{
+		{
+			name: "InstalledSentinelDetected_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(0, "", "")
+			},
+			spec:         validPdbSpec(),
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "LivePdbDetected_NoSentinel_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(probeCmd).Returns(0, "PDB1\n", "")
+			},
+			spec:         validPdbSpec(),
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "PartialSentinelDetected_ReturnsError",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(probeCmd).Returns(0, "\n", "")
+				m.OnCommand("test -f " + partial).Returns(0, "", "")
+			},
+			spec:         validPdbSpec(),
+			wantErr:      "partial pdb state",
+			wantDetected: DetectionStatePartial,
+		},
+		{
+			name: "AbsentPdb_RunsFullPipeline",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(probeCmd).Returns(0, "\n", "")
+				m.OnCommand("test -f " + partial).Returns(1, "", "")
+				m.OnCommand(mkdir).Returns(0, "", "")
+				m.OnCommand(dbca).Returns(0, "Prepare for db operation\n100% complete\nPluggable database creation complete.\n", "")
+				m.OnCommand(mv).Returns(0, "", "")
+			},
+			spec:            validPdbSpec(),
+			wantSkipped:     false,
+			wantDetected:    DetectionStateInstalled,
+			wantLogContains: "Pluggable database creation complete",
+		},
+		{
+			name: "DbcaExitNonzero_LeavesPartialAndErrors",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(probeCmd).Returns(0, "\n", "")
+				m.OnCommand("test -f " + partial).Returns(1, "", "")
+				m.OnCommand(mkdir).Returns(0, "", "")
+				m.OnCommand(dbca).Returns(1, "[FATAL] DBT-50000: insufficient resources\n", "")
+			},
+			spec:            validPdbSpec(),
+			wantErr:         "exit 1",
+			wantDetected:    DetectionStatePartial,
+			wantLogContains: "DBT-50000",
+		},
+		{
+			name: "Reset_OnInstalled_PrintsRunbook_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(0, "", "")
+			},
+			spec:         validPdbSpec(),
+			reset:        true,
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "Reset_OnPartial_PrintsRunbook_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f " + installed).Returns(1, "", "")
+				m.OnCommand(probeCmd).Returns(0, "\n", "")
+				m.OnCommand("test -f " + partial).Returns(0, "", "")
+			},
+			spec:         validPdbSpec(),
+			reset:        true,
+			wantSkipped:  true,
+			wantDetected: DetectionStatePartial,
+		},
+		{
+			name:      "RejectsMissingTarget",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: PdbCreateSpec{
+				InstallSpec:       InstallSpec{OracleHome: "/x", OracleBase: "/y"},
+				CdbName:           "ORCL",
+				PdbName:           "PDB1",
+				AdminPasswordFile: "/tmp/pw",
+			},
+			wantErr:      "target is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsMissingOracleBase",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: PdbCreateSpec{
+				InstallSpec:       InstallSpec{Target: "x", OracleHome: "/x"},
+				CdbName:           "ORCL",
+				PdbName:           "PDB1",
+				AdminPasswordFile: "/tmp/pw",
+			},
+			wantErr:      "oracle_base is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsMissingCdbName",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: PdbCreateSpec{
+				InstallSpec:       InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				PdbName:           "PDB1",
+				AdminPasswordFile: "/tmp/pw",
+			},
+			wantErr:      "cdb_name is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsMissingPdbName",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: PdbCreateSpec{
+				InstallSpec:       InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				CdbName:           "ORCL",
+				AdminPasswordFile: "/tmp/pw",
+			},
+			wantErr:      "pdb_name is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsMissingAdminPasswordFile",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: PdbCreateSpec{
+				InstallSpec: InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				CdbName:     "ORCL",
+				PdbName:     "PDB1",
+			},
+			wantErr:      "admin_password_file is required",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsCdbNameWithShellMetachar_Semicolon",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: PdbCreateSpec{
+				InstallSpec:       InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				CdbName:           "ORCL;rm -rf /",
+				PdbName:           "PDB1",
+				AdminPasswordFile: "/tmp/pw",
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsPdbNameWithBacktick",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: PdbCreateSpec{
+				InstallSpec:       InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				CdbName:           "ORCL",
+				PdbName:           "PDB1`whoami`",
+				AdminPasswordFile: "/tmp/pw",
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsPdbNameWithDollar",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: PdbCreateSpec{
+				InstallSpec:       InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				CdbName:           "ORCL",
+				PdbName:           "PDB1$(id)",
+				AdminPasswordFile: "/tmp/pw",
+			},
+			wantErr:      "disallowed character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsTargetWithNewline",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: PdbCreateSpec{
+				InstallSpec:       InstallSpec{Target: "x\nrm -rf /", OracleHome: "/x", OracleBase: "/y"},
+				CdbName:           "ORCL",
+				PdbName:           "PDB1",
+				AdminPasswordFile: "/tmp/pw",
+			},
+			wantErr:      "control character",
+			wantDetected: DetectionStateUnset,
+		},
+		{
+			name:      "RejectsAdminPasswordFileWithNewline",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec: PdbCreateSpec{
+				InstallSpec:       InstallSpec{Target: "x", OracleHome: "/x", OracleBase: "/y"},
+				CdbName:           "ORCL",
+				PdbName:           "PDB1",
+				AdminPasswordFile: "/tmp/pw\nrm -rf /",
+			},
+			wantErr:      "control character",
+			wantDetected: DetectionStateUnset,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := hosttest.NewMockExecutor()
+			tc.setupMock(mock)
+			res, err := pdbCreateWithExec(context.Background(), mock, tc.spec, tc.reset)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				if tc.wantLogContains != "" && res != nil {
+					assert.Contains(t, res.LogTail, tc.wantLogContains)
+				}
+				if tc.wantDetected != DetectionStateUnset && res != nil {
+					assert.Equal(t, tc.wantDetected, res.Detected)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			assert.Equal(t, tc.wantSkipped, res.Skipped)
+			assert.Equal(t, tc.wantDetected, res.Detected)
+			if tc.wantLogContains != "" {
+				assert.Contains(t, res.LogTail, tc.wantLogContains)
+			}
+		})
+	}
+}
+
+// TestPdbCreate_WithResponseFile asserts the alternate dbca CLI shape
+// (-responseFile) is selected when ResponseFilePath is set.
+func TestPdbCreate_WithResponseFile(t *testing.T) {
+	spec := validPdbSpec()
+	spec.ResponseFilePath = "/tmp/pdb.rsp"
+
+	const partial = "/u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.partial"
+	const installed = "/u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.installed"
+	const probeSQL = "set heading off pagesize 0 feedback off; select name from v$pdbs where name = upper('PDB1'); exit;"
+	probeCmd := "echo " + shellEscape(probeSQL) + " | env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/sqlplus -s / as sysdba"
+	const mkdir = "mkdir -p /u01/app/oracle/cfgtoollogs/dbx && : > /u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.partial"
+	const dbca = "env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/dbca -silent -createPluggableDatabase -responseFile /tmp/pdb.rsp"
+	const mv = "mv /u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.partial /u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.installed"
+
+	mock := hosttest.NewMockExecutor()
+	mock.OnCommand("test -f " + installed).Returns(1, "", "")
+	mock.OnCommand(probeCmd).Returns(0, "\n", "")
+	mock.OnCommand("test -f " + partial).Returns(1, "", "")
+	mock.OnCommand(mkdir).Returns(0, "", "")
+	mock.OnCommand(dbca).Returns(0, "Pluggable database creation complete.\n", "")
+	mock.OnCommand(mv).Returns(0, "", "")
+
+	res, err := pdbCreateWithExec(context.Background(), mock, spec, false)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.False(t, res.Skipped)
+	assert.Equal(t, DetectionStateInstalled, res.Detected)
+}
+
+// TestPdbCreate_WithDatafileDest asserts -pdbDatafileDestination is
+// appended when DatafileDest is set.
+func TestPdbCreate_WithDatafileDest(t *testing.T) {
+	spec := validPdbSpec()
+	spec.DatafileDest = "+DATA"
+
+	const installed = "/u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.installed"
+	const partial = "/u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.partial"
+	const probeSQL = "set heading off pagesize 0 feedback off; select name from v$pdbs where name = upper('PDB1'); exit;"
+	probeCmd := "echo " + shellEscape(probeSQL) + " | env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/sqlplus -s / as sysdba"
+	const mkdir = "mkdir -p /u01/app/oracle/cfgtoollogs/dbx && : > /u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.partial"
+	dbca := "env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/dbca -silent -createPluggableDatabase -sourceDB ORCL -pdbName PDB1 -pdbAdminUserName PDBADMIN -pdbAdminPasswordFile /tmp/pdbadmin.pw -pdbDatafileDestination " + shellEscape("+DATA")
+	const mv = "mv /u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.partial /u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.installed"
+
+	mock := hosttest.NewMockExecutor()
+	mock.OnCommand("test -f " + installed).Returns(1, "", "")
+	mock.OnCommand(probeCmd).Returns(0, "\n", "")
+	mock.OnCommand("test -f " + partial).Returns(1, "", "")
+	mock.OnCommand(mkdir).Returns(0, "", "")
+	mock.OnCommand(dbca).Returns(0, "OK\n", "")
+	mock.OnCommand(mv).Returns(0, "", "")
+
+	res, err := pdbCreateWithExec(context.Background(), mock, spec, false)
+	require.NoError(t, err)
+	assert.Equal(t, DetectionStateInstalled, res.Detected)
+}
+
+// pdbCtxCancelExec — same pattern as dbcaCtxCancelExec.
+type pdbCtxCancelExec struct {
+	inner       host.Executor
+	cancelAfter int
+	calls       int
+	cancel      context.CancelFunc
+	wrapErr     error
+}
+
+func (e *pdbCtxCancelExec) Run(ctx context.Context, cmd string) (*host.RunResult, error) {
+	e.calls++
+	if e.calls <= e.cancelAfter {
+		return e.inner.Run(ctx, cmd)
+	}
+	if e.cancel != nil {
+		e.cancel()
+	}
+	return nil, e.wrapErr
+}
+
+func TestPdbCreate_CtxCancelled_ReportsPartial(t *testing.T) {
+	const installed = "/u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.installed"
+	const partial = "/u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.partial"
+	const probeSQL = "set heading off pagesize 0 feedback off; select name from v$pdbs where name = upper('PDB1'); exit;"
+	probeCmd := "echo " + shellEscape(probeSQL) + " | env ORACLE_HOME=/u01/app/oracle/product/19c/dbhome_1 /u01/app/oracle/product/19c/dbhome_1/bin/sqlplus -s / as sysdba"
+	const mkdir = "mkdir -p /u01/app/oracle/cfgtoollogs/dbx && : > /u01/app/oracle/cfgtoollogs/dbx/pdb.ORCL.PDB1.partial"
+
+	mock := hosttest.NewMockExecutor()
+	mock.OnCommand("test -f " + installed).Returns(1, "", "")
+	mock.OnCommand(probeCmd).Returns(0, "\n", "")
+	mock.OnCommand("test -f " + partial).Returns(1, "", "")
+	mock.OnCommand(mkdir).Returns(0, "", "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ex := &pdbCtxCancelExec{
+		inner:       mock,
+		cancelAfter: 4, // 3 probes (installed, sqlplus, partial) + 1 sentinel-write
+		cancel:      cancel,
+		wrapErr:     errors.New("transport: connection closed"),
+	}
+
+	res, err := pdbCreateWithExec(ctx, ex, validPdbSpec(), false)
+	require.Error(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, DetectionStatePartial, res.Detected)
+	assert.Contains(t, err.Error(), "interrupted")
+	assert.Contains(t, err.Error(), "may still be running")
+}

--- a/pkg/provision/install/rootsh.go
+++ b/pkg/provision/install/rootsh.go
@@ -33,7 +33,7 @@ func rootShWithExec(ctx context.Context, exec host.Executor, spec InstallSpec, r
 	}
 
 	touch := spec.OracleHome + "/install/rootsh.touchfile"
-	exists, _, err := probeFile(ctx, exec, touch)
+	exists, err := probeFile(ctx, exec, touch)
 	if err != nil {
 		return nil, fmt.Errorf("probe touchfile on %s: %w", spec.Target, err)
 	}
@@ -53,6 +53,13 @@ func rootShWithExec(ctx context.Context, exec host.Executor, spec InstallSpec, r
 	cmd := fmt.Sprintf("%s/root.sh && touch %s", shellEscape(spec.OracleHome), shellEscape(touch))
 	runRes, err := exec.Run(ctx, cmd)
 	if err != nil {
+		// If the local context was cancelled, the remote process may
+		// still be running on the target. Surface this as Partial so
+		// the next probe can pick it up; touchfile won't exist yet.
+		if ctx.Err() != nil {
+			res.Detected = DetectionStatePartial
+			return res, fmt.Errorf("root.sh interrupted (ctx %v); remote process may still be running on %s; next run will see partial state: %w", ctx.Err(), spec.Target, err)
+		}
 		return nil, fmt.Errorf("root.sh transport failure: %w", err)
 	}
 	res.ExitCode = runRes.ExitCode

--- a/pkg/provision/install/rootsh.go
+++ b/pkg/provision/install/rootsh.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/itunified-io/dbx/pkg/host"
+	"github.com/itunified-io/dbx/pkg/otel"
 )
 
 // RootSh runs <OracleHome>/root.sh on the target host. The wrapped
@@ -27,7 +28,15 @@ func RootSh(ctx context.Context, spec InstallSpec, reset bool) (*InstallResult, 
 
 // rootShWithExec is the testable core. Takes an injected executor so
 // unit tests can use hosttest.MockExecutor.
-func rootShWithExec(ctx context.Context, exec host.Executor, spec InstallSpec, reset bool) (*InstallResult, error) {
+func rootShWithExec(ctx context.Context, exec host.Executor, spec InstallSpec, reset bool) (res *InstallResult, retErr error) {
+	sb := otel.NewSpan("provision.install.root_sh", "dbxcli").
+		WithAttrs(
+			otel.StringAttr(otel.AttrDbxHost, spec.Target),
+			otel.StringAttr(otel.AttrDbxEntityType, "oracle_root_sh"),
+			otel.StringAttr(otel.AttrDbxEntityName, spec.OracleHome),
+		)
+	defer func() { emitSpan(ctx, sb, retErr) }()
+
 	if err := spec.Validate(); err != nil {
 		return nil, err
 	}
@@ -38,7 +47,7 @@ func rootShWithExec(ctx context.Context, exec host.Executor, spec InstallSpec, r
 		return nil, fmt.Errorf("probe touchfile on %s: %w", spec.Target, err)
 	}
 
-	res := &InstallResult{}
+	res = &InstallResult{}
 	if exists {
 		res.Detected = DetectionStateInstalled
 		if !reset {

--- a/pkg/provision/install/rootsh.go
+++ b/pkg/provision/install/rootsh.go
@@ -1,0 +1,64 @@
+package install
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/itunified-io/dbx/pkg/host"
+)
+
+// RootSh runs <OracleHome>/root.sh on the target host. The wrapped
+// command escalates to root via the Executor's configured ssh-user
+// (must be root, or have NOPASSWD sudo). Idempotent per Oracle docs;
+// we use a sentinel touchfile to skip-on-detect for clean audit
+// chains. Version-agnostic: relies on file existence only, not
+// content match — detection is valid for 19c, 21c, 23ai, and 26ai.
+//
+// Unlike Grid/DBHome, --reset is allowed on this primitive: root.sh
+// is documented as safe to re-run, so --reset simply re-executes
+// without erroring.
+func RootSh(ctx context.Context, spec InstallSpec, reset bool) (*InstallResult, error) {
+	exec, err := newSSHExecutor(ctx, spec.Target)
+	if err != nil {
+		return nil, fmt.Errorf("ssh to %s: %w", spec.Target, err)
+	}
+	return rootShWithExec(ctx, exec, spec, reset)
+}
+
+// rootShWithExec is the testable core. Takes an injected executor so
+// unit tests can use hosttest.MockExecutor.
+func rootShWithExec(ctx context.Context, exec host.Executor, spec InstallSpec, reset bool) (*InstallResult, error) {
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+
+	touch := spec.OracleHome + "/install/rootsh.touchfile"
+	exists, _, err := probeFile(ctx, exec, touch)
+	if err != nil {
+		return nil, fmt.Errorf("probe touchfile on %s: %w", spec.Target, err)
+	}
+
+	res := &InstallResult{}
+	if exists {
+		res.Detected = DetectionStateInstalled
+		if !reset {
+			res.Skipped = true
+			return res, nil
+		}
+		// fall through: --reset means "re-run anyway" (root.sh is idempotent)
+	} else {
+		res.Detected = DetectionStateAbsent
+	}
+
+	cmd := fmt.Sprintf("%s/root.sh && touch %s", shellEscape(spec.OracleHome), shellEscape(touch))
+	runRes, err := exec.Run(ctx, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("root.sh transport failure: %w", err)
+	}
+	res.ExitCode = runRes.ExitCode
+	res.LogTail = tailLog(runRes.Stdout+runRes.Stderr, 100)
+	if runRes.ExitCode != 0 {
+		return res, fmt.Errorf("install: root.sh exit %d on %s", runRes.ExitCode, spec.Target)
+	}
+	return res, nil
+}

--- a/pkg/provision/install/rootsh_test.go
+++ b/pkg/provision/install/rootsh_test.go
@@ -2,8 +2,10 @@ package install
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/itunified-io/dbx/pkg/host"
 	"github.com/itunified-io/dbx/pkg/host/hosttest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,7 +25,7 @@ func TestRootSh(t *testing.T) {
 		{
 			name: "DetectsExistingTouchfile_Skips",
 			setupMock: func(m *hosttest.MockExecutor) {
-				m.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile && cat /u01/app/19c/grid/install/rootsh.touchfile").
+				m.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile").
 					Returns(0, "ran 2026-04-30T10:00:00Z\n", "")
 			},
 			spec:         InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/grid"},
@@ -33,7 +35,7 @@ func TestRootSh(t *testing.T) {
 		{
 			name: "AbsentTouchfile_RunsScript",
 			setupMock: func(m *hosttest.MockExecutor) {
-				m.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile && cat /u01/app/19c/grid/install/rootsh.touchfile").
+				m.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile").
 					Returns(1, "", "")
 				m.OnCommand("/u01/app/19c/grid/root.sh && touch /u01/app/19c/grid/install/rootsh.touchfile").
 					Returns(0, "Performing root user operation.\nThe following environment variables are set as:\n\n", "")
@@ -46,7 +48,7 @@ func TestRootSh(t *testing.T) {
 		{
 			name: "ScriptExitNonZero_ReturnsError",
 			setupMock: func(m *hosttest.MockExecutor) {
-				m.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile && cat /u01/app/19c/grid/install/rootsh.touchfile").
+				m.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile").
 					Returns(1, "", "")
 				m.OnCommand("/u01/app/19c/grid/root.sh && touch /u01/app/19c/grid/install/rootsh.touchfile").
 					Returns(5, "ERROR: ROOT.SH operation failed\n", "")
@@ -65,7 +67,7 @@ func TestRootSh(t *testing.T) {
 		{
 			name: "ResetOnInstalled_ReRunsScript",
 			setupMock: func(m *hosttest.MockExecutor) {
-				m.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile && cat /u01/app/19c/grid/install/rootsh.touchfile").
+				m.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile").
 					Returns(0, "ran 2026-04-30T10:00:00Z\n", "")
 				m.OnCommand("/u01/app/19c/grid/root.sh && touch /u01/app/19c/grid/install/rootsh.touchfile").
 					Returns(0, "Performing root user operation again.\n", "")
@@ -100,4 +102,50 @@ func TestRootSh(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ctxCancelExec runs the first command (the touchfile probe) normally
+// via the inner mock; on the SECOND command (the install command) it
+// behaves as if the context had been cancelled mid-run — it returns
+// ctx.Err() (or a sentinel) without ever producing a RunResult. The
+// caller's ctx is also cancelled before the second call to make
+// ctx.Err() reflect that state.
+type ctxCancelExec struct {
+	inner   host.Executor
+	calls   int
+	cancel  context.CancelFunc
+	wrapErr error
+}
+
+func (e *ctxCancelExec) Run(ctx context.Context, cmd string) (*host.RunResult, error) {
+	e.calls++
+	if e.calls == 1 {
+		return e.inner.Run(ctx, cmd)
+	}
+	// Simulate ctx cancellation observed by the underlying transport.
+	if e.cancel != nil {
+		e.cancel()
+	}
+	return nil, e.wrapErr
+}
+
+func TestRootSh_CtxCancelled_ReportsPartial(t *testing.T) {
+	mock := hosttest.NewMockExecutor()
+	mock.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile").Returns(1, "", "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ex := &ctxCancelExec{
+		inner:   mock,
+		cancel:  cancel,
+		wrapErr: errors.New("transport: connection closed"),
+	}
+
+	spec := InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/grid"}
+	res, err := rootShWithExec(ctx, ex, spec, false)
+
+	require.Error(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, DetectionStatePartial, res.Detected)
+	assert.Contains(t, err.Error(), "interrupted")
+	assert.Contains(t, err.Error(), "may still be running")
 }

--- a/pkg/provision/install/rootsh_test.go
+++ b/pkg/provision/install/rootsh_test.go
@@ -1,0 +1,103 @@
+package install
+
+import (
+	"context"
+	"testing"
+
+	"github.com/itunified-io/dbx/pkg/host/hosttest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootSh(t *testing.T) {
+	cases := []struct {
+		name            string
+		setupMock       func(*hosttest.MockExecutor)
+		spec            InstallSpec
+		reset           bool
+		wantErr         string
+		wantSkipped     bool
+		wantDetected    DetectionState
+		wantLogContains string
+	}{
+		{
+			name: "DetectsExistingTouchfile_Skips",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile && cat /u01/app/19c/grid/install/rootsh.touchfile").
+					Returns(0, "ran 2026-04-30T10:00:00Z\n", "")
+			},
+			spec:         InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/grid"},
+			wantSkipped:  true,
+			wantDetected: DetectionStateInstalled,
+		},
+		{
+			name: "AbsentTouchfile_RunsScript",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile && cat /u01/app/19c/grid/install/rootsh.touchfile").
+					Returns(1, "", "")
+				m.OnCommand("/u01/app/19c/grid/root.sh && touch /u01/app/19c/grid/install/rootsh.touchfile").
+					Returns(0, "Performing root user operation.\nThe following environment variables are set as:\n\n", "")
+			},
+			spec:            InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/grid"},
+			wantSkipped:     false,
+			wantDetected:    DetectionStateAbsent,
+			wantLogContains: "Performing root user operation",
+		},
+		{
+			name: "ScriptExitNonZero_ReturnsError",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile && cat /u01/app/19c/grid/install/rootsh.touchfile").
+					Returns(1, "", "")
+				m.OnCommand("/u01/app/19c/grid/root.sh && touch /u01/app/19c/grid/install/rootsh.touchfile").
+					Returns(5, "ERROR: ROOT.SH operation failed\n", "")
+			},
+			spec:            InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/grid"},
+			wantErr:         "exit 5",
+			wantLogContains: "ROOT.SH operation failed",
+			wantDetected:    DetectionStateAbsent,
+		},
+		{
+			name:      "RejectsInvalidSpec",
+			setupMock: func(m *hosttest.MockExecutor) {},
+			spec:      InstallSpec{},
+			wantErr:   "target is required",
+		},
+		{
+			name: "ResetOnInstalled_ReRunsScript",
+			setupMock: func(m *hosttest.MockExecutor) {
+				m.OnCommand("test -f /u01/app/19c/grid/install/rootsh.touchfile && cat /u01/app/19c/grid/install/rootsh.touchfile").
+					Returns(0, "ran 2026-04-30T10:00:00Z\n", "")
+				m.OnCommand("/u01/app/19c/grid/root.sh && touch /u01/app/19c/grid/install/rootsh.touchfile").
+					Returns(0, "Performing root user operation again.\n", "")
+			},
+			spec:            InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/grid"},
+			reset:           true,
+			wantSkipped:     false,
+			wantDetected:    DetectionStateInstalled,
+			wantLogContains: "again",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := hosttest.NewMockExecutor()
+			tc.setupMock(mock)
+			res, err := rootShWithExec(context.Background(), mock, tc.spec, tc.reset)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				if tc.wantLogContains != "" && res != nil {
+					assert.Contains(t, res.LogTail, tc.wantLogContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			assert.Equal(t, tc.wantSkipped, res.Skipped)
+			assert.Equal(t, tc.wantDetected, res.Detected)
+			if tc.wantLogContains != "" {
+				assert.Contains(t, res.LogTail, tc.wantLogContains)
+			}
+		})
+	}
+}

--- a/pkg/provision/install/types.go
+++ b/pkg/provision/install/types.go
@@ -138,3 +138,41 @@ func (s AsmcaSpec) Validate() error {
 	}
 	return nil
 }
+
+// NetcaSpec configures listener creation via netca silent. Used during
+// Phase D.2 (post-Grid, pre-DBCA) to ensure a LISTENER exists for client
+// connections AND during Phase E.2 to add static services on a standby
+// for RMAN DUPLICATE.
+//
+// OracleBase is required because the two-phase sentinel pair lives under
+// <OracleBase>/cfgtoollogs/dbx/netca.<LISTENER>.{partial,installed}.
+type NetcaSpec struct {
+	InstallSpec
+	ListenerName string `json:"listener_name"` // e.g. "LISTENER"
+	Port         int    `json:"port"`          // e.g. 1521
+}
+
+// Validate extends InstallSpec.Validate with listener-specific checks.
+func (s NetcaSpec) Validate() error {
+	if err := s.InstallSpec.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(s.OracleBase) == "" {
+		return fmt.Errorf("install: oracle_base is required for netca (sentinel path)")
+	}
+	if strings.TrimSpace(s.ListenerName) == "" {
+		return fmt.Errorf("install: listener_name is required")
+	}
+	// Reject control chars + shell metachars on the listener name. Mirrors
+	// AsmcaSpec.Validate's defense-in-depth check on disk entries; the
+	// listener name is interpolated into both the lsnrctl status command
+	// and the sentinel filename, neither of which tolerate metacharacters.
+	const disallowed = "\n\r \t$`!&|;'\"\\<>*?(){}[]"
+	if strings.ContainsAny(s.ListenerName, disallowed) {
+		return fmt.Errorf("install: listener_name contains disallowed character: %q", s.ListenerName)
+	}
+	if s.Port <= 0 || s.Port > 65535 {
+		return fmt.Errorf("install: port must be 1-65535, got %d", s.Port)
+	}
+	return nil
+}

--- a/pkg/provision/install/types.go
+++ b/pkg/provision/install/types.go
@@ -300,6 +300,104 @@ func (s DbcaCreateDbSpec) Validate() error {
 	return nil
 }
 
+// PdbCreateSpec configures silent PDB creation via `dbca -silent
+// -createPluggableDatabase`. Phase D.5 of /lab-up — runs after the
+// parent CDB exists (Phase D.4 dbca -createDatabase) and before any
+// PDB-scoped tooling.
+//
+// Sentinels are keyed on the parent CDB's DB_UNIQUE_NAME PLUS the PDB
+// name so a same-named PDB in two different CDBs on the same host
+// does not collide:
+//
+//	<OracleBase>/cfgtoollogs/dbx/pdb.<CDB>.<PDB>.{partial,installed}
+//
+// Passwords MUST be passed via files on the target host
+// (AdminPasswordFile) — never on the command line where they would
+// leak into ps(1) output and audit records. The caller (skill) is
+// responsible for placing those files (mode 0600, oracle-owned) on
+// the host before invoking this primitive.
+//
+// ResponseFilePath is OPTIONAL: when set, dbca is invoked with
+// -responseFile <path>; when empty, dbca is invoked with direct CLI
+// args (-pdbName, -createAsContainerDatabase). The CLI-arg form is
+// the common case; the response-file form supports advanced templates
+// (custom datafile placement, SEED FILE_NAME_CONVERT, etc.).
+type PdbCreateSpec struct {
+	InstallSpec
+	// CdbName is the parent CDB's DB_UNIQUE_NAME (used in the sentinel
+	// path AND as the sqlplus connection key for the live probe).
+	CdbName string `json:"cdb_name"`
+	// PdbName is the new PDB's name (used in the sentinel path AND as
+	// the v$pdbs probe key + dbca -pdbName argument).
+	PdbName string `json:"pdb_name"`
+	// AdminPasswordFile is the absolute path on the target host to a
+	// file containing the new PDB's admin user password (mode 0600,
+	// oracle-owned). REQUIRED.
+	AdminPasswordFile string `json:"admin_password_file"`
+	// DatafileDest is an optional `+DATA` ASM diskgroup or absolute
+	// filesystem path. When empty, dbca uses the CDB's default
+	// (DB_CREATE_FILE_DEST or the response-file value).
+	DatafileDest string `json:"datafile_dest,omitempty"`
+}
+
+// Validate extends InstallSpec.Validate with PDB-specific checks.
+// ResponseFilePath is OPTIONAL for PdbCreateSpec (overrides the
+// embedded InstallSpec validation which treats it as required-when-set).
+func (s PdbCreateSpec) Validate() error {
+	// We can't call s.InstallSpec.Validate() blindly because some leaves
+	// require ResponseFilePath and some don't; instead repeat the
+	// generic checks here and treat ResponseFilePath as optional.
+	if strings.TrimSpace(s.Target) == "" {
+		return fmt.Errorf("install: target is required")
+	}
+	if strings.TrimSpace(s.OracleHome) == "" {
+		return fmt.Errorf("install: oracle_home is required")
+	}
+	for _, f := range []struct{ name, value string }{
+		{"target", s.Target},
+		{"oracle_home", s.OracleHome},
+		{"oracle_base", s.OracleBase},
+		{"software_staging", s.SoftwareStaging},
+		{"response_file_path", s.ResponseFilePath},
+	} {
+		if strings.ContainsAny(f.value, "\n\r") {
+			return fmt.Errorf("install: field contains control character: %s", f.name)
+		}
+	}
+	if strings.TrimSpace(s.OracleBase) == "" {
+		return fmt.Errorf("install: oracle_base is required for pdb create (sentinel path)")
+	}
+	if strings.TrimSpace(s.CdbName) == "" {
+		return fmt.Errorf("install: cdb_name is required")
+	}
+	if strings.TrimSpace(s.PdbName) == "" {
+		return fmt.Errorf("install: pdb_name is required")
+	}
+	if strings.TrimSpace(s.AdminPasswordFile) == "" {
+		return fmt.Errorf("install: admin_password_file is required (passwords must NEVER be on the command line)")
+	}
+	// Reject control chars + shell metachars on cdb_name and pdb_name.
+	// Both are interpolated into the sqlplus probe AND the sentinel
+	// filename, neither of which tolerate metacharacters.
+	const disallowed = "\n\r \t$`!&|;'\"\\<>*?(){}[]"
+	if strings.ContainsAny(s.CdbName, disallowed) {
+		return fmt.Errorf("install: cdb_name contains disallowed character: %q", s.CdbName)
+	}
+	if strings.ContainsAny(s.PdbName, disallowed) {
+		return fmt.Errorf("install: pdb_name contains disallowed character: %q", s.PdbName)
+	}
+	// Reject control chars on the optional path-like fields.
+	for _, f := range []struct{ name, value string }{
+		{"admin_password_file", s.AdminPasswordFile},
+		{"datafile_dest", s.DatafileDest},
+	} {
+		if f.value != "" && strings.ContainsAny(f.value, "\n\r") {
+			return fmt.Errorf("install: field contains control character: %s", f.name)
+		}
+	}
+	return nil
+}
+
 // NetcaSpec configures listener creation via netca silent. Used during
 // Phase D.2 (post-Grid, pre-DBCA) to ensure a LISTENER exists for client
 // connections AND during Phase E.2 to add static services on a standby

--- a/pkg/provision/install/types.go
+++ b/pkg/provision/install/types.go
@@ -1,9 +1,3 @@
-// Package install ships Oracle install primitives — runInstaller,
-// root.sh, asmca, netca, oracleasm/afd disk labeling — invoked by
-// /lab-up Phase D skills via dbxcli provision install <action>.
-//
-// All functions in this package require Enterprise license tier
-// (license.RequireTier checked at the cobra layer, not here).
 package install
 
 import (
@@ -29,13 +23,27 @@ type InstallSpec struct {
 	ResponseFilePath string `json:"response_file_path"`
 }
 
-// Validate returns an error if required fields are missing.
+// Validate returns an error if required fields are missing or contain
+// disallowed characters. \n and \r are rejected on every field as a
+// command-injection guard: shellEscape quoting alone does not stop
+// embedded newlines from being interpreted by some shell contexts.
 func (s InstallSpec) Validate() error {
 	if strings.TrimSpace(s.Target) == "" {
 		return fmt.Errorf("install: target is required")
 	}
 	if strings.TrimSpace(s.OracleHome) == "" {
 		return fmt.Errorf("install: oracle_home is required")
+	}
+	for _, f := range []struct{ name, value string }{
+		{"target", s.Target},
+		{"oracle_home", s.OracleHome},
+		{"oracle_base", s.OracleBase},
+		{"software_staging", s.SoftwareStaging},
+		{"response_file_path", s.ResponseFilePath},
+	} {
+		if strings.ContainsAny(f.value, "\n\r") {
+			return fmt.Errorf("install: field contains control character: %s", f.name)
+		}
 	}
 	return nil
 }

--- a/pkg/provision/install/types.go
+++ b/pkg/provision/install/types.go
@@ -139,6 +139,107 @@ func (s AsmcaSpec) Validate() error {
 	return nil
 }
 
+// AsmDiskLabelImpl identifies which raw-disk labeling backend is used.
+// One of "asmlib" (Oracle ASMlib via /usr/sbin/oracleasm) or "afd"
+// (Oracle ASM Filter Driver via <grid_home>/bin/asmcmd afd_label).
+const (
+	AsmDiskLabelImplAsmlib = "asmlib"
+	AsmDiskLabelImplAFD    = "afd"
+)
+
+// AsmLabelEntry pairs a raw block device with the ASM label to assign.
+type AsmLabelEntry struct {
+	Name   string `json:"name"`   // e.g. "DATA1"
+	Device string `json:"device"` // e.g. "/dev/sdb"
+}
+
+// AsmDiskLabelSpec configures raw-disk → ASM-discoverable labeling.
+// Phase D.1 prerequisite to AsmcaSilent. Per-label sentinels live at
+// <oracle_base>/cfgtoollogs/dbx/asm-label.<NAME>.{partial,installed}.
+type AsmDiskLabelSpec struct {
+	Target         string          `json:"target"`
+	GridHome       string          `json:"grid_home"`      // $GRID_HOME (provides bin/asmcmd for AFD)
+	OracleBase     string          `json:"oracle_base"`    // sentinel root
+	Implementation string          `json:"implementation"` // "asmlib" | "afd"
+	Labels         []AsmLabelEntry `json:"labels"`
+}
+
+// AsmDiskLabelResult lists per-label results.
+type AsmDiskLabelResult struct {
+	Implementation string                   `json:"implementation"`
+	Labels         []AsmDiskLabelLabelResult `json:"labels,omitempty"`
+}
+
+// AsmDiskLabelLabelResult is the per-label outcome.
+type AsmDiskLabelLabelResult struct {
+	Name     string         `json:"name"`
+	Device   string         `json:"device"`
+	Detected DetectionState `json:"detected"`
+	Skipped  bool           `json:"skipped"`
+	ExitCode int            `json:"exit_code"`
+	LogTail  string         `json:"log_tail,omitempty"`
+}
+
+// Validate returns an error if required fields are missing or contain
+// disallowed characters. Mirrors AsmcaSpec/NetcaSpec defense-in-depth:
+// every shell-interpolated string is checked for control chars + shell
+// metacharacters in addition to shellEscape at the call site.
+func (s AsmDiskLabelSpec) Validate() error {
+	if strings.TrimSpace(s.Target) == "" {
+		return fmt.Errorf("install: target is required")
+	}
+	if strings.TrimSpace(s.GridHome) == "" {
+		return fmt.Errorf("install: grid_home is required")
+	}
+	if strings.TrimSpace(s.OracleBase) == "" {
+		return fmt.Errorf("install: oracle_base is required for asm-label (sentinel path)")
+	}
+	switch s.Implementation {
+	case AsmDiskLabelImplAsmlib, AsmDiskLabelImplAFD:
+	default:
+		return fmt.Errorf("install: implementation must be %q or %q, got %q",
+			AsmDiskLabelImplAsmlib, AsmDiskLabelImplAFD, s.Implementation)
+	}
+	if len(s.Labels) == 0 {
+		return fmt.Errorf("install: labels list is required")
+	}
+	// Reject control chars on the path-like fields.
+	for _, f := range []struct{ name, value string }{
+		{"target", s.Target},
+		{"grid_home", s.GridHome},
+		{"oracle_base", s.OracleBase},
+	} {
+		if strings.ContainsAny(f.value, "\n\r") {
+			return fmt.Errorf("install: field contains control character: %s", f.name)
+		}
+	}
+	// Per-label defense-in-depth: reject control chars + shell metachars
+	// on both Name and Device. shellEscape at the call site handles
+	// quoting, but these fields end up in sentinel filenames + lsblk-
+	// adjacent commands where embedded metachars must never reach.
+	const disallowed = "\n\r \t$`!&|;'\"\\<>*?(){}[]"
+	seen := map[string]bool{}
+	for i, l := range s.Labels {
+		if strings.TrimSpace(l.Name) == "" {
+			return fmt.Errorf("install: labels[%d].name is required", i)
+		}
+		if strings.TrimSpace(l.Device) == "" {
+			return fmt.Errorf("install: labels[%d].device is required", i)
+		}
+		if strings.ContainsAny(l.Name, disallowed) {
+			return fmt.Errorf("install: labels[%d].name contains disallowed character: %q", i, l.Name)
+		}
+		if strings.ContainsAny(l.Device, disallowed+",") {
+			return fmt.Errorf("install: labels[%d].device contains disallowed character: %q", i, l.Device)
+		}
+		if seen[l.Name] {
+			return fmt.Errorf("install: labels[%d].name %q is duplicated", i, l.Name)
+		}
+		seen[l.Name] = true
+	}
+	return nil
+}
+
 // NetcaSpec configures listener creation via netca silent. Used during
 // Phase D.2 (post-Grid, pre-DBCA) to ensure a LISTENER exists for client
 // connections AND during Phase E.2 to add static services on a standby

--- a/pkg/provision/install/types.go
+++ b/pkg/provision/install/types.go
@@ -1,0 +1,79 @@
+// Package install ships Oracle install primitives — runInstaller,
+// root.sh, asmca, netca, oracleasm/afd disk labeling — invoked by
+// /lab-up Phase D skills via dbxcli provision install <action>.
+//
+// All functions in this package require Enterprise license tier
+// (license.RequireTier checked at the cobra layer, not here).
+package install
+
+import (
+	"fmt"
+	"strings"
+)
+
+// InstallSpec is the common input for all install primitives. Tool-
+// specific extensions (GridSpec, DBHomeSpec, etc.) embed it.
+type InstallSpec struct {
+	// Target is the dbx target name (resolves to host + SSH config via
+	// dbx/pkg/core/target).
+	Target string `json:"target"`
+	// OracleHome is the destination $ORACLE_HOME (or $GRID_HOME) path.
+	OracleHome string `json:"oracle_home"`
+	// OracleBase is /u01/app/oracle (or /u01/app/grid).
+	OracleBase string `json:"oracle_base"`
+	// SoftwareStaging is the local-on-host path where unzipped Oracle
+	// software lives (e.g. /smb/software/oracle/19c/grid_home).
+	SoftwareStaging string `json:"software_staging"`
+	// ResponseFilePath is the absolute path on the target host where
+	// the rendered response file (.rsp) was placed by the caller (skill).
+	ResponseFilePath string `json:"response_file_path"`
+}
+
+// Validate returns an error if required fields are missing.
+func (s InstallSpec) Validate() error {
+	if strings.TrimSpace(s.Target) == "" {
+		return fmt.Errorf("install: target is required")
+	}
+	if strings.TrimSpace(s.OracleHome) == "" {
+		return fmt.Errorf("install: oracle_home is required")
+	}
+	return nil
+}
+
+// InstallResult is the common output for all install primitives.
+type InstallResult struct {
+	// Detected is the pre-flight detection result.
+	Detected DetectionState `json:"detected"`
+	// Skipped is true when Detected != Absent and operator did not
+	// pass --reset (no work performed).
+	Skipped bool `json:"skipped"`
+	// LogTail captures the last 100 lines of installer/script stdout+stderr
+	// for debugging. Empty when Skipped=true.
+	LogTail string `json:"log_tail,omitempty"`
+	// ExitCode is the wrapped command's exit code (0 = success, non-zero
+	// is preserved in Error before propagation up the call stack).
+	ExitCode int `json:"exit_code"`
+}
+
+// DetectionState is the pre-flight idempotency probe outcome.
+type DetectionState int
+
+const (
+	DetectionStateAbsent    DetectionState = iota // No prior install evidence on target
+	DetectionStatePartial                          // Some evidence; install was started but not finished
+	DetectionStateInstalled                        // Full prior install detected; safe to skip
+)
+
+// String implements fmt.Stringer.
+func (s DetectionState) String() string {
+	switch s {
+	case DetectionStateAbsent:
+		return "absent"
+	case DetectionStatePartial:
+		return "partial"
+	case DetectionStateInstalled:
+		return "installed"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/provision/install/types.go
+++ b/pkg/provision/install/types.go
@@ -240,6 +240,66 @@ func (s AsmDiskLabelSpec) Validate() error {
 	return nil
 }
 
+// DbcaCreateDbSpec configures silent CDB creation via `dbca -silent
+// -createDatabase -responseFile <path>`. Phase D.4 of /lab-up.
+//
+// OracleBase is required because the two-phase sentinel pair lives under
+// <OracleBase>/cfgtoollogs/dbx/dbca.<DB_UNIQUE_NAME>.{partial,installed}.
+//
+// Passwords MUST be passed via files on the target host (SysPasswordFile,
+// SystemPasswordFile) — never on the command line where they would leak
+// into ps(1) output and audit records. The caller (skill) is responsible
+// for placing those files (mode 0600, oracle-owned) on the host before
+// invoking this primitive.
+type DbcaCreateDbSpec struct {
+	InstallSpec
+	// DbUniqueName is the DB_UNIQUE_NAME for the database (used in the
+	// sentinel path AND as the live-probe key for `srvctl status database`).
+	DbUniqueName string `json:"db_unique_name"`
+	// SysPasswordFile is an optional absolute path to a file on the
+	// target host containing the SYS password. dbca reads it via
+	// -sysPassword via -responseFile (caller may also embed the password
+	// in the response file). Both forms are supported; this field is a
+	// hint for the runbook only.
+	SysPasswordFile string `json:"sys_password_file,omitempty"`
+	// SystemPasswordFile is the analogous path for the SYSTEM password.
+	SystemPasswordFile string `json:"system_password_file,omitempty"`
+}
+
+// Validate extends InstallSpec.Validate with dbca-specific checks.
+func (s DbcaCreateDbSpec) Validate() error {
+	if err := s.InstallSpec.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(s.OracleBase) == "" {
+		return fmt.Errorf("install: oracle_base is required for dbca (sentinel path)")
+	}
+	if strings.TrimSpace(s.ResponseFilePath) == "" {
+		return fmt.Errorf("install: response_file_path is required (caller must render + scp the dbca .rsp first)")
+	}
+	if strings.TrimSpace(s.DbUniqueName) == "" {
+		return fmt.Errorf("install: db_unique_name is required")
+	}
+	// Reject control chars + shell metachars on db_unique_name. Mirrors
+	// AsmcaSpec/NetcaSpec defense-in-depth: db_unique_name is interpolated
+	// into both the srvctl probe AND the sentinel filename, neither of
+	// which tolerate metacharacters.
+	const disallowed = "\n\r \t$`!&|;'\"\\<>*?(){}[]"
+	if strings.ContainsAny(s.DbUniqueName, disallowed) {
+		return fmt.Errorf("install: db_unique_name contains disallowed character: %q", s.DbUniqueName)
+	}
+	// Password-file paths are optional; reject control chars only.
+	for _, f := range []struct{ name, value string }{
+		{"sys_password_file", s.SysPasswordFile},
+		{"system_password_file", s.SystemPasswordFile},
+	} {
+		if f.value != "" && strings.ContainsAny(f.value, "\n\r") {
+			return fmt.Errorf("install: field contains control character: %s", f.name)
+		}
+	}
+	return nil
+}
+
 // NetcaSpec configures listener creation via netca silent. Used during
 // Phase D.2 (post-Grid, pre-DBCA) to ensure a LISTENER exists for client
 // connections AND during Phase E.2 to add static services on a standby

--- a/pkg/provision/install/types.go
+++ b/pkg/provision/install/types.go
@@ -85,3 +85,45 @@ func (s DetectionState) String() string {
 		return "unknown"
 	}
 }
+
+// AsmcaSpec configures an initial ASM diskgroup creation. Used ONLY for
+// the first DG (DATA, RECO) — subsequent diskgroup operations go through
+// mcp-oracle-ee-asm tools which assume ASM is already up.
+type AsmcaSpec struct {
+	InstallSpec
+	DGName     string   `json:"dg_name"`    // e.g. "DATA"
+	Redundancy string   `json:"redundancy"` // "EXTERNAL" | "NORMAL" | "HIGH"
+	AUSizeMB   int      `json:"au_size_mb"` // e.g. 4
+	Disks      []string `json:"disks"`      // ["/dev/sdb", "/dev/sdc"] OR ["AFD:DATA1", ...]
+}
+
+// Validate extends InstallSpec.Validate with DG-specific checks.
+// OracleBase is required (sentinels live under <oracle_base>/cfgtoollogs/dbx/).
+func (s AsmcaSpec) Validate() error {
+	if err := s.InstallSpec.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(s.OracleBase) == "" {
+		return fmt.Errorf("install: oracle_base is required for asmca (sentinel path)")
+	}
+	if strings.TrimSpace(s.DGName) == "" {
+		return fmt.Errorf("install: dg_name is required")
+	}
+	switch s.Redundancy {
+	case "EXTERNAL", "NORMAL", "HIGH":
+	default:
+		return fmt.Errorf("install: redundancy must be EXTERNAL/NORMAL/HIGH, got %q", s.Redundancy)
+	}
+	if s.AUSizeMB <= 0 {
+		return fmt.Errorf("install: au_size_mb must be > 0")
+	}
+	if len(s.Disks) == 0 {
+		return fmt.Errorf("install: disks list is required")
+	}
+	for _, d := range s.Disks {
+		if strings.ContainsAny(d, "\n\r,") {
+			return fmt.Errorf("install: disk entry contains control character or comma: %q", d)
+		}
+	}
+	return nil
+}

--- a/pkg/provision/install/types.go
+++ b/pkg/provision/install/types.go
@@ -68,8 +68,14 @@ type DetectionState int
 
 const (
 	DetectionStateAbsent    DetectionState = iota // No prior install evidence on target
-	DetectionStatePartial                          // Some evidence; install was started but not finished
-	DetectionStateInstalled                        // Full prior install detected; safe to skip
+	DetectionStatePartial                         // Some evidence; install was started but not finished
+	DetectionStateInstalled                       // Full prior install detected; safe to skip
+
+	// DetectionStateUnset is a test-only sentinel for table-driven
+	// cases that don't care to assert a specific Detected state.
+	// Real probes never return Unset; it lives outside the iota
+	// sequence so the zero value of DetectionState remains Absent.
+	DetectionStateUnset DetectionState = -1
 )
 
 // String implements fmt.Stringer.
@@ -120,9 +126,14 @@ func (s AsmcaSpec) Validate() error {
 	if len(s.Disks) == 0 {
 		return fmt.Errorf("install: disks list is required")
 	}
+	// Reject control chars, comma (the join separator), and shell
+	// metacharacters that would survive shellEscape on the joined
+	// argument. The whole join is shell-escaped at the call site, but
+	// individual entries are still defended-in-depth here.
+	const disallowed = "\n\r, \t$`!&|;'\"\\<>*?(){}[]"
 	for _, d := range s.Disks {
-		if strings.ContainsAny(d, "\n\r,") {
-			return fmt.Errorf("install: disk entry contains control character or comma: %q", d)
+		if strings.ContainsAny(d, disallowed) {
+			return fmt.Errorf("install: disk entry contains disallowed character: %q", d)
 		}
 	}
 	return nil

--- a/pkg/provision/install/types_test.go
+++ b/pkg/provision/install/types_test.go
@@ -1,0 +1,48 @@
+package install
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstallSpec_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    InstallSpec
+		wantErr string // empty string = no error expected
+	}{
+		{"missing target", InstallSpec{}, "target is required"},
+		{"missing oracle_home", InstallSpec{Target: "ext3adm1"}, "oracle_home is required"},
+		{"valid spec", InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/grid"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.spec.Validate()
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDetectionState_String(t *testing.T) {
+	cases := []struct {
+		state DetectionState
+		want  string
+	}{
+		{DetectionStateAbsent, "absent"},
+		{DetectionStatePartial, "partial"},
+		{DetectionStateInstalled, "installed"},
+		{DetectionState(99), "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.state.String())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Plan 0a of the /lab-up Phase D + E master plan (infrastructure issue #519). Ships `dbxcli provision install …` subcommands wrapping Oracle silent installs end-to-end.

**8 install primitives** (Cobra leaves under `dbxcli provision install`):
- `grid` — runInstaller silent for Grid Infrastructure
- `dbhome` — runInstaller silent for Oracle DB home
- `root-sh` — root.sh execution + idempotency touchfile
- `asmca` — asmca silent diskgroup creation
- `netca` — netca silent listener creation
- `asm-label` — oracleasm/AFD disk labeling
- `dbca` — DBCA silent CDB creation
- `pdb` — DBCA silent PDB creation

**Cross-cutting properties (all 8):**
- Idempotent (two-phase `.partial`/`.installed` sentinel for non-idempotent ops; touchfile for root.sh)
- ctx-cancel safe (mid-run interrupt → DetectionStatePartial)
- Version-agnostic detection (no version-string substring matches)
- Shell-injection hardened (control-char + metachar Validate; shellEscape on every arg)
- \`env ORACLE_HOME=<home> <home>/bin/<bin>\`-qualified probes (no bare commands)
- \`--reset\` MVP non-destructive (prints recovery runbook to stderr)
- OTEL span per invocation with dbx.* attributes (NoopExporter default)

## Follow-ups

- dbx#26 — audit chain integration (Plan 0a Task 9; blocked on \`pkg/audit/\` not yet existing)
- dbx#27 — RequireBundle license gate (Plan 0a Task 11; blocked on \`pkg/license/\` not yet existing)

## Test plan

- [x] \`go test ./... -race -count=1\` green at HEAD
- [x] \`go build ./...\` clean
- [x] OTEL capture-exporter test verifies one span per primitive
- [x] E2e cobra smoke tests for all 8 leaves
- [x] CalVer tag v2026.05.01.1 created + pushed

Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)