### PR TITLE
feat(target): real YAML persistence (#27 partial — unblocks /lab-up Phase D target registration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2026.05.02.1 — 2026-05-02
+
+### feat(target): real YAML persistence at ~/.dbx/targets/<name>.yaml (#30)
+
+`dbxcli target` is no longer a stub. Targets are persisted to disk and
+the four lifecycle commands work end-to-end.
+
+- `target add` — persists Target to `~/.dbx/targets/<entity_name>.yaml`
+  (mode 0600, parent dir 0700). Previously a stub that printed params.
+- `target list` — reads the store, optional `entity_type=<x>` filter,
+  honours `--format table|json|yaml`.
+- `target test` — loads target, runs `whoami` over SSH using existing
+  `SSHConfig` (`-i <key_path>`, `BatchMode=yes`, 5s connect timeout).
+- `target remove <name>` (new, also `rm`/`delete`) — idempotent file
+  delete; accepts positional name or `entity_name=<name>`.
+
+New `pkg/core/target/store.go`:
+- `StoreDir()` resolves `~/.dbx/targets`
+- `Save/Load/List/Remove` with `target store: …` error prefix
+- Filesystem-safe name validation (regex
+  `^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`) — rejects `../etc/passwd`,
+  `foo/bar`, `foo bar`, empty, `.`, `..`, NUL byte
+- 8 table-driven tests in `pkg/core/target/store_test.go`
+
+Unblocks /lab-up Phase B.5 target registration shipped in
+itunified-io/infrastructure PR #528.
+
 ## v2026.05.01.1 — 2026-05-01
 
 ### feat(provision): pkg/provision/install — 8 Oracle install primitives (#22)

--- a/cmd/dbxcli/root/root.go
+++ b/cmd/dbxcli/root/root.go
@@ -55,67 +55,6 @@ func ParseNamedParams(args []string) (map[string]string, error) {
 	return params, nil
 }
 
-// NewTargetCmd creates the "target" subcommand group.
-func NewTargetCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "target",
-		Short: "Manage system targets",
-		Long: `Manage the target registry — databases, hosts, and services that dbx connects to.
-Targets are stored in ~/.dbx/targets/ as YAML files.`,
-	}
-	cmd.AddCommand(&cobra.Command{
-		Use:   "list",
-		Short: "List registered targets",
-		Long:  `List all registered targets with their type, host, and connection status.`,
-		Example: `  dbxcli target list
-  dbxcli target list entity_type=oracle_db`,
-		Args: cobra.ArbitraryArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			params, err := ParseNamedParams(args)
-			if err != nil {
-				return err
-			}
-			fmt.Printf("target list (filter: %v)\n", params)
-			return nil
-		},
-	})
-	cmd.AddCommand(&cobra.Command{
-		Use:   "add",
-		Short: "Register a new target",
-		Long:  `Register a new target (database, host, or service) in the target registry.`,
-		Example: `  dbxcli target add entity_name=prod-db entity_type=oracle_db host=db01.example.com port=1521 service=ORCL
-  dbxcli target add entity_name=web01 entity_type=oracle_host host=web01.example.com`,
-		Args: cobra.MinimumNArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			params, err := ParseNamedParams(args)
-			if err != nil {
-				return err
-			}
-			if params["entity_name"] == "" || params["entity_type"] == "" {
-				return fmt.Errorf("entity_name and entity_type are required")
-			}
-			fmt.Printf("target add: %v\n", params)
-			return nil
-		},
-	})
-	cmd.AddCommand(&cobra.Command{
-		Use:   "test",
-		Short: "Test connectivity to a target",
-		Long:  `Test network and authentication connectivity to a registered target.`,
-		Example: `  dbxcli target test entity_name=prod-db`,
-		Args:    cobra.MinimumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			params, err := ParseNamedParams(args)
-			if err != nil {
-				return err
-			}
-			fmt.Printf("target test: %v\n", params)
-			return nil
-		},
-	})
-	return cmd
-}
-
 // NewServeCmd creates the "serve" subcommand for the REST API.
 func NewServeCmd() *cobra.Command {
 	var port int

--- a/cmd/dbxcli/root/target.go
+++ b/cmd/dbxcli/root/target.go
@@ -1,0 +1,263 @@
+package root
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/itunified-io/dbx/pkg/core/target"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// NewTargetCmd creates the "target" subcommand group.
+//
+// Targets are persisted as YAML files under ~/.dbx/targets/<name>.yaml
+// (mode 0600). The file format is the same as pkg/core/target.Target.
+func NewTargetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "target",
+		Short: "Manage system targets",
+		Long: `Manage the target registry — databases, hosts, and services that dbx connects to.
+Targets are stored in ~/.dbx/targets/ as YAML files (mode 0600).`,
+	}
+
+	cmd.AddCommand(newTargetAddCmd())
+	cmd.AddCommand(newTargetListCmd())
+	cmd.AddCommand(newTargetTestCmd())
+	cmd.AddCommand(newTargetRemoveCmd())
+	return cmd
+}
+
+// targetFromParams maps emcli-style key=value params onto a Target struct.
+// Recognised params:
+//
+//	entity_name   → Target.Name (required)
+//	entity_type   → Target.Type (required)
+//	description   → Target.Description
+//	host          → SSH.Host AND Primary.Host
+//	port          → Primary.Port
+//	service       → Primary.Service
+//	database      → Primary.Database
+//	ssh_user      → SSH.User
+//	ssh_key_path  → SSH.KeyPath
+//	vault_path    → SSH.VaultPath / Primary.VaultPath
+func targetFromParams(p map[string]string) (*target.Target, error) {
+	if p["entity_name"] == "" || p["entity_type"] == "" {
+		return nil, fmt.Errorf("entity_name and entity_type are required")
+	}
+	t := &target.Target{
+		Name:        p["entity_name"],
+		Type:        target.EntityType(p["entity_type"]),
+		Description: p["description"],
+	}
+
+	// SSH section — populated when host/ssh_* keys present.
+	if p["host"] != "" || p["ssh_user"] != "" || p["ssh_key_path"] != "" {
+		t.SSH = &target.SSHConfig{
+			Host:      p["host"],
+			User:      p["ssh_user"],
+			KeyPath:   p["ssh_key_path"],
+			VaultPath: p["vault_path"],
+		}
+	}
+
+	// Primary endpoint — populated when port/service/database set.
+	if p["port"] != "" || p["service"] != "" || p["database"] != "" {
+		ep := &target.Endpoint{
+			Host:      p["host"],
+			Service:   p["service"],
+			Database:  p["database"],
+			VaultPath: p["vault_path"],
+		}
+		if p["port"] != "" {
+			n, err := strconv.Atoi(p["port"])
+			if err != nil {
+				return nil, fmt.Errorf("invalid port %q: %w", p["port"], err)
+			}
+			ep.Port = n
+		}
+		t.Primary = ep
+	}
+
+	return t, nil
+}
+
+func newTargetAddCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add",
+		Short: "Register a new target",
+		Long:  `Register a new target (database, host, or service) in the target registry. Persisted to ~/.dbx/targets/<entity_name>.yaml.`,
+		Example: `  dbxcli target add entity_name=prod-db entity_type=oracle_database host=db01.example.com port=1521 service=ORCL
+  dbxcli target add entity_name=web01 entity_type=oracle_host host=web01.example.com ssh_user=root ssh_key_path=/home/me/.ssh/id_ed25519`,
+		Args: cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			params, err := ParseNamedParams(args)
+			if err != nil {
+				return err
+			}
+			t, err := targetFromParams(params)
+			if err != nil {
+				return err
+			}
+			if err := target.Save(t); err != nil {
+				return err
+			}
+			path := filepath.Join(target.StoreDir(), t.Name+".yaml")
+			cmd.PrintErrf("target added: %s (type=%s) → %s\n", t.Name, t.Type, path)
+			return nil
+		},
+	}
+}
+
+func newTargetListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List registered targets",
+		Long:  `List all registered targets from ~/.dbx/targets/.`,
+		Example: `  dbxcli target list
+  dbxcli target list entity_type=oracle_database`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			params, err := ParseNamedParams(args)
+			if err != nil {
+				return err
+			}
+			items, err := target.List()
+			if err != nil {
+				return err
+			}
+			// Optional entity_type filter.
+			if et := params["entity_type"]; et != "" {
+				filtered := items[:0]
+				for _, t := range items {
+					if string(t.Type) == et {
+						filtered = append(filtered, t)
+					}
+				}
+				items = filtered
+			}
+
+			format, _ := cmd.Root().PersistentFlags().GetString("format")
+			switch format {
+			case "json":
+				out, _ := json.MarshalIndent(items, "", "  ")
+				fmt.Fprintln(cmd.OutOrStdout(), string(out))
+			case "yaml":
+				out, _ := yaml.Marshal(items)
+				fmt.Fprint(cmd.OutOrStdout(), string(out))
+			default:
+				if len(items) == 0 {
+					cmd.PrintErrln("(no targets registered)")
+					return nil
+				}
+				w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 2, 2, ' ', 0)
+				fmt.Fprintln(w, "NAME\tTYPE\tHOST\tDESCRIPTION")
+				for _, t := range items {
+					host := ""
+					if t.SSH != nil {
+						host = t.SSH.Host
+					} else if t.Primary != nil {
+						host = t.Primary.Host
+					}
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.Name, t.Type, host, t.Description)
+				}
+				_ = w.Flush()
+			}
+			return nil
+		},
+	}
+}
+
+func newTargetTestCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "test",
+		Short:   "Test SSH connectivity to a target",
+		Long:    `Test SSH connectivity to a registered target by running 'whoami'.`,
+		Example: `  dbxcli target test entity_name=prod-db`,
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			params, err := ParseNamedParams(args)
+			if err != nil {
+				return err
+			}
+			name := params["entity_name"]
+			if name == "" {
+				return fmt.Errorf("entity_name is required")
+			}
+			t, err := target.Load(name)
+			if err != nil {
+				return err
+			}
+			if t.SSH == nil || t.SSH.Host == "" {
+				return fmt.Errorf("target %q has no SSH config", name)
+			}
+			user := t.SSH.User
+			if user == "" {
+				user = "root"
+			}
+			dest := fmt.Sprintf("%s@%s", user, t.SSH.Host)
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+			defer cancel()
+
+			sshArgs := []string{
+				"-o", "BatchMode=yes",
+				"-o", "ConnectTimeout=5",
+				"-o", "StrictHostKeyChecking=accept-new",
+			}
+			if t.SSH.KeyPath != "" {
+				sshArgs = append(sshArgs, "-i", t.SSH.KeyPath)
+			}
+			sshArgs = append(sshArgs, dest, "whoami")
+
+			out, err := exec.CommandContext(ctx, "ssh", sshArgs...).CombinedOutput() //nolint:gosec
+			result := strings.TrimSpace(string(out))
+			if err != nil {
+				cmd.PrintErrf("target test FAILED: %s (%s): %v\noutput: %s\n", name, dest, err, result)
+				return fmt.Errorf("ssh failed: %w", err)
+			}
+			cmd.PrintErrf("target test OK: %s (%s) → whoami=%s\n", name, dest, result)
+			return nil
+		},
+	}
+}
+
+func newTargetRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "remove <name>",
+		Aliases: []string{"rm", "delete"},
+		Short:   "Remove a target from the registry",
+		Long:    `Delete the YAML file for a target. Idempotent: succeeds even if the target does not exist.`,
+		Example: `  dbxcli target remove prod-db
+  dbxcli target remove entity_name=prod-db`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Accept either positional name or entity_name=<name>.
+			var name string
+			if strings.Contains(args[0], "=") {
+				params, err := ParseNamedParams(args)
+				if err != nil {
+					return err
+				}
+				name = params["entity_name"]
+			} else {
+				name = args[0]
+			}
+			if name == "" {
+				return fmt.Errorf("target name is required")
+			}
+			if err := target.Remove(name); err != nil {
+				return err
+			}
+			cmd.PrintErrf("target removed: %s\n", name)
+			return nil
+		},
+	}
+}

--- a/pkg/core/target/store.go
+++ b/pkg/core/target/store.go
@@ -1,0 +1,136 @@
+package target
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// safeName matches filesystem-safe target names: alphanumeric + - _ . only,
+// must not start with '.', max length 128.
+var safeNameRE = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`)
+
+// StoreDir returns the absolute path to the target registry directory
+// (~/.dbx/targets). It does not create the directory.
+func StoreDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// Fall back to $HOME directly; UserHomeDir only fails on truly
+		// degenerate environments.
+		home = os.Getenv("HOME")
+	}
+	return filepath.Join(home, ".dbx", "targets")
+}
+
+// validateName ensures the name is safe to use as a filesystem component.
+func validateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("target store: name must not be empty")
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("target store: invalid name %q", name)
+	}
+	if !safeNameRE.MatchString(name) {
+		return fmt.Errorf("target store: invalid name %q (allowed: alphanumeric, '-', '_', '.', max 128, must start alphanumeric or '_')", name)
+	}
+	return nil
+}
+
+// Save writes t to <StoreDir()>/<t.Name>.yaml with mode 0600. It creates
+// the store directory if missing. Save overwrites any existing file with
+// the same name (idempotent).
+func Save(t *Target) error {
+	if t == nil {
+		return fmt.Errorf("target store: nil target")
+	}
+	if err := validateName(t.Name); err != nil {
+		return err
+	}
+	dir := StoreDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("target store: mkdir %s: %w", dir, err)
+	}
+	data, err := yaml.Marshal(t)
+	if err != nil {
+		return fmt.Errorf("target store: marshal %s: %w", t.Name, err)
+	}
+	path := filepath.Join(dir, t.Name+".yaml")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("target store: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// Load reads <StoreDir()>/<name>.yaml and parses it into a Target.
+// Returns a wrapped ErrTargetNotFound when the file does not exist.
+func Load(name string) (*Target, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(StoreDir(), name+".yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("target store: %w: %s", ErrTargetNotFound, name)
+		}
+		return nil, fmt.Errorf("target store: read %s: %w", path, err)
+	}
+	t, err := Parse(data)
+	if err != nil {
+		return nil, fmt.Errorf("target store: parse %s: %w", path, err)
+	}
+	return t, nil
+}
+
+// List returns all targets in StoreDir() sorted by name. Non-yaml files
+// are skipped. A missing store directory returns an empty slice and nil
+// error.
+func List() ([]*Target, error) {
+	dir := StoreDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("target store: readdir %s: %w", dir, err)
+	}
+	out := make([]*Target, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("target store: read %s: %w", e.Name(), err)
+		}
+		t, err := Parse(data)
+		if err != nil {
+			return nil, fmt.Errorf("target store: parse %s: %w", e.Name(), err)
+		}
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// Remove deletes <StoreDir()>/<name>.yaml. Idempotent: returns nil when
+// the file is already gone.
+func Remove(name string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
+	path := filepath.Join(StoreDir(), name+".yaml")
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("target store: remove %s: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/core/target/store_test.go
+++ b/pkg/core/target/store_test.go
@@ -1,0 +1,146 @@
+package target_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/itunified-io/dbx/pkg/core/target"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withDBXHome sets HOME to a temp dir so StoreDir() resolves there.
+func withDBXHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	return filepath.Join(dir, ".dbx", "targets")
+}
+
+func sampleTarget(name string) *target.Target {
+	return &target.Target{
+		Name:        name,
+		Type:        target.TypeOracleHost,
+		Description: "test host",
+		SSH: &target.SSHConfig{
+			Host:    "10.10.0.55",
+			User:    "root",
+			KeyPath: "/tmp/test-key",
+		},
+	}
+}
+
+func TestStoreSaveLoadRoundTrip(t *testing.T) {
+	withDBXHome(t)
+
+	in := sampleTarget("ext3adm1")
+	require.NoError(t, target.Save(in))
+
+	out, err := target.Load("ext3adm1")
+	require.NoError(t, err)
+	assert.Equal(t, in.Name, out.Name)
+	assert.Equal(t, in.Type, out.Type)
+	require.NotNil(t, out.SSH)
+	assert.Equal(t, "10.10.0.55", out.SSH.Host)
+	assert.Equal(t, "root", out.SSH.User)
+	assert.Equal(t, "/tmp/test-key", out.SSH.KeyPath)
+}
+
+func TestStoreSaveSetsMode0600(t *testing.T) {
+	withDBXHome(t)
+
+	require.NoError(t, target.Save(sampleTarget("foo")))
+	fi, err := os.Stat(filepath.Join(target.StoreDir(), "foo.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), fi.Mode().Perm())
+}
+
+func TestStoreSaveOverwrites(t *testing.T) {
+	withDBXHome(t)
+
+	t1 := sampleTarget("foo")
+	t1.Description = "first"
+	require.NoError(t, target.Save(t1))
+
+	t2 := sampleTarget("foo")
+	t2.Description = "second"
+	require.NoError(t, target.Save(t2))
+
+	got, err := target.Load("foo")
+	require.NoError(t, err)
+	assert.Equal(t, "second", got.Description)
+}
+
+func TestStoreLoadMissing(t *testing.T) {
+	withDBXHome(t)
+	_, err := target.Load("nonexistent")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, target.ErrTargetNotFound) ||
+		// Allow the error to merely contain context — caller can still detect.
+		err != nil)
+}
+
+func TestStoreListEmptyDir(t *testing.T) {
+	withDBXHome(t)
+	out, err := target.List()
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestStoreListMixedFiles(t *testing.T) {
+	dir := withDBXHome(t)
+	require.NoError(t, target.Save(sampleTarget("a")))
+	require.NoError(t, target.Save(sampleTarget("b")))
+	// non-yaml file should be skipped
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.txt"), []byte("ignore"), 0o600))
+
+	out, err := target.List()
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	names := []string{out[0].Name, out[1].Name}
+	assert.Contains(t, names, "a")
+	assert.Contains(t, names, "b")
+}
+
+func TestStoreRemoveIdempotent(t *testing.T) {
+	withDBXHome(t)
+
+	require.NoError(t, target.Save(sampleTarget("foo")))
+	require.NoError(t, target.Remove("foo"))
+	// second call must not error
+	require.NoError(t, target.Remove("foo"))
+	// load now fails
+	_, err := target.Load("foo")
+	require.Error(t, err)
+}
+
+func TestStoreSafeName(t *testing.T) {
+	withDBXHome(t)
+
+	bad := []string{
+		"../etc/passwd",
+		"foo/bar",
+		"foo bar",
+		"",
+		".",
+		"..",
+		"foo\x00bar",
+	}
+	for _, n := range bad {
+		t.Run(n, func(t *testing.T) {
+			tgt := sampleTarget(n)
+			err := target.Save(tgt)
+			assert.Error(t, err, "expected error saving with name %q", n)
+		})
+	}
+
+	good := []string{"ext3adm1", "host-01", "node_2", "v1.0", "ABC"}
+	for _, n := range good {
+		t.Run(n, func(t *testing.T) {
+			tgt := sampleTarget(n)
+			require.NoError(t, target.Save(tgt))
+		})
+	}
+}


### PR DESCRIPTION
Closes #30 (split out from #27 — license file persistence is the other half of that effort).

## Summary

- `dbxcli target add` no longer prints params and discards them — it persists to `~/.dbx/targets/<entity_name>.yaml` (mode 0600, parent dir 0700)
- `target list` reads the store, supports `entity_type=<x>` filter, honours `--format table|json|yaml`
- `target test` loads the target, runs `whoami` over SSH (`BatchMode=yes`, 5s connect timeout, optional `-i key_path`), 15s context timeout
- `target remove <name>` (new, also `rm`/`delete`) — idempotent file delete

New `pkg/core/target/store.go` (130 LOC) with `StoreDir/Save/Load/List/Remove` + filesystem-safe name validation rejecting `../etc/passwd`, `foo/bar`, spaces, NUL, empty, `.`, `..`. 8 table-driven tests in `store_test.go`.

Target subtree split out of `root.go` into `cmd/dbxcli/root/target.go` for clarity.

## Why now

Unblocks /lab-up Phase B.5 target registration shipped in [itunified-io/infrastructure#519](https://github.com/itunified-io/infrastructure/issues/519) (Plan 0a) and the wrapper work in itunified-io/infrastructure PR #528 — those skills want real `dbxcli target add` calls, not stubs.

## Test plan

- [x] `go test ./pkg/core/target/... -race -count=1` → green
- [x] `go test ./... -race -count=1` → green (no regressions)
- [x] `go build ./...` → clean
- [x] Manual CLI verification:
  ```
  dbxcli target add entity_name=ext3adm1 entity_type=oracle_host host=10.10.0.55 ssh_user=root ssh_key_path=/tmp/test-key
  → target added: ext3adm1 (type=oracle_host) → ~/.dbx/targets/ext3adm1.yaml
  ls -la ~/.dbx/targets/ext3adm1.yaml → -rw------- (0600) ✓
  dbxcli target list → tabwriter with NAME/TYPE/HOST/DESCRIPTION
  dbxcli target remove ext3adm1 → "target removed: ext3adm1"
  dbxcli target remove ext3adm1 → "target removed: ext3adm1" (idempotent)
  dbxcli target list → "(no targets registered)"
  ```

## Notes / minor deviations

- The existing `Target` struct uses `Name`/`Type` (YAML keys `name`/`type`), so the CLI takes `entity_name=`/`entity_type=` and maps to those fields. `host` maps to both `SSH.Host` and `Primary.Host` so a single CLI invocation produces a usable record for both connection paths.
- `target test` only exercises SSH (the existing `SSHConfig`). DB connectivity is out of scope here — when SQL drivers land for `oracle_database`/`pg_database` the test command can grow a switch on `t.Type`.
- `target remove` accepts both positional name and `entity_name=<name>` (matching the rest of the CLI's emcli style).