### PR TITLE
feat(license): pkg/license/ Ed25519 JWT + RequireBundle on install primitives (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2026.05.03.1 — 2026-05-03
+
+### feat(license): pkg/license/ + RequireBundle gating on 8 provision install primitives (#27)
+
+Slim Ed25519-JWT tier-gate facade for the dbxcli, plus enforcement
+on every Oracle install primitive. Closes the TODO(#519) markers
+introduced in PR #28.
+
+- New package `pkg/license/`:
+  - `types.go` — `Tier` ordering (community < business < enterprise),
+    `License` with `HasBundle/HasTier/IsValid`, `ErrTierGate` sentinel
+    that wraps the underlying `ErrMissing`/`ErrExpired`/...
+  - `jwt.go` — minimal compact JWS (Ed25519/EdDSA only). Strict
+    algorithm pinning rejects `none`, `HS256`, etc.
+  - `store.go` — license at `~/.dbx/license.jwt` (mode 0600). Embedded
+    production verification key at `pkg/license/keys/prod.pub` (empty
+    placeholder until license CA is provisioned). Dev keys auto-trusted
+    via `~/.dbx/.trust/*.pub`.
+  - `issuer.go` — DEV-MODE: `IssueDev` self-signs with
+    `~/.dbx/.signing-key.ed25519`, idempotent across calls. Stamps the
+    `dev: true` claim so the verifier prints a warning on Load.
+  - `require.go` — `RequireBundle(name)` and `RequireTier(min)`. Bundle
+    gates implicitly require Enterprise tier.
+- Wired `license.RequireBundle("provision")` at the top of every
+  `dbxcli provision install <leaf>` RunE: grid, dbhome, root-sh, asmca,
+  netca, asm-label, dbca, pdb. Replaces the placeholder
+  `// TODO(#519): wire license.RequireBundle…` markers.
+- New `cmd/dbxcli/root/license.go`:
+  - `dbxcli license status` — table view of tier/bundles/expiry/source.
+  - `dbxcli license activate <path>` — verifies + installs a JWT.
+  - `dbxcli license issue …` — DEV-MODE self-sign with `--tier`,
+    `--bundles`, `--subject`, `--expires`, `--out`.
+- 22 new tests (sign/verify roundtrip, alg pinning, unknown-signer
+  rejection, expired/wrong-tier/wrong-bundle gates, dev key idempotency,
+  file mode 0600). Existing e2e test updated to accept the new
+  tier-gate error path.
+
 ## v2026.05.02.1 — 2026-05-02
 
 ### feat(target): real YAML persistence at ~/.dbx/targets/<name>.yaml (#30)

--- a/cmd/dbxcli/root/license.go
+++ b/cmd/dbxcli/root/license.go
@@ -1,0 +1,215 @@
+package root
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/itunified-io/dbx/pkg/license"
+	"github.com/spf13/cobra"
+)
+
+// newLicenseCmd builds the "dbxcli license" command tree.
+//
+// Subcommands:
+//   - status   show current state of ~/.dbx/license.jwt
+//   - activate <path>  install a JWT file as the active license
+//   - issue   DEV-MODE: self-sign a license with a local Ed25519 key
+func newLicenseCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "license",
+		Short: "Manage dbx license",
+		Long: `Manage the dbx license. Licenses are Ed25519-signed JWT tokens stored
+at ~/.dbx/license.jwt (mode 0600). Without a license, only Community
+(OSS) features are available — Enterprise tier + matching bundles
+unlock gated commands such as ` + "`provision install`" + `.`,
+	}
+	cmd.AddCommand(newLicenseStatusCmd())
+	cmd.AddCommand(newLicenseActivateCmd())
+	cmd.AddCommand(newLicenseIssueCmd())
+	return cmd
+}
+
+func newLicenseStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show license status",
+		Long: `Show current license status: tier, bundles, expiry, and whether the
+license is dev-issued (self-signed locally) or production-signed.`,
+		Example: `  dbxcli license status`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLicenseStatus(cmd.OutOrStdout())
+		},
+	}
+}
+
+func runLicenseStatus(w io.Writer) error {
+	lic, err := license.Load()
+	if errors.Is(err, license.ErrMissing) {
+		fmt.Fprintln(w, "license: OSS (no license file)")
+		fmt.Fprintln(w, "         Community-tier features only.")
+		fmt.Fprintln(w, "         To self-sign a dev license: dbxcli license issue --tier enterprise --bundles provision")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("load license: %w", err)
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "license\t: %s\n", license.Path())
+	fmt.Fprintf(tw, "subject\t: %s\n", lic.Subject)
+	fmt.Fprintf(tw, "tier\t: %s\n", lic.Tier)
+	fmt.Fprintf(tw, "bundles\t: %s\n", strings.Join(lic.Bundles, ", "))
+	if lic.IssuedAt > 0 {
+		fmt.Fprintf(tw, "issued\t: %s\n", time.Unix(lic.IssuedAt, 0).UTC().Format(time.RFC3339))
+	}
+	if lic.ExpiresAt > 0 {
+		fmt.Fprintf(tw, "expires\t: %s\n", time.Unix(lic.ExpiresAt, 0).UTC().Format(time.RFC3339))
+	} else {
+		fmt.Fprintf(tw, "expires\t: never\n")
+	}
+	if lic.Dev {
+		fmt.Fprintf(tw, "source\t: dev-issued (self-signed) — NOT for production\n")
+	} else {
+		fmt.Fprintf(tw, "source\t: production-signed\n")
+	}
+	if vErr := lic.IsValid(); vErr != nil {
+		fmt.Fprintf(tw, "state\t: INVALID — %s\n", vErr)
+	} else {
+		fmt.Fprintf(tw, "state\t: valid\n")
+	}
+	return tw.Flush()
+}
+
+func newLicenseActivateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "activate <path>",
+		Short: "Activate a license file",
+		Long: `Read the JWT at <path>, verify it against trusted keys, and on
+success copy it to ~/.dbx/license.jwt (mode 0600).`,
+		Example: `  dbxcli license activate /path/to/license.jwt`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("read %s: %w", args[0], err)
+			}
+			if err := license.Save(strings.TrimSpace(string(data))); err != nil {
+				return err
+			}
+			// Re-load to validate signature against the trust list.
+			if _, err := license.Load(); err != nil {
+				return fmt.Errorf("activated file failed verification: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "license activated: %s\n", license.Path())
+			return runLicenseStatus(cmd.OutOrStdout())
+		},
+	}
+	return cmd
+}
+
+func newLicenseIssueCmd() *cobra.Command {
+	var (
+		tier     string
+		bundles  []string
+		subject  string
+		expires  string
+		outPath  string
+	)
+	cmd := &cobra.Command{
+		Use:   "issue",
+		Short: "DEV-MODE: self-sign a license",
+		Long: `DEV-MODE ONLY. Self-sign a license JWT using a locally-generated
+Ed25519 key at ~/.dbx/.signing-key.ed25519, with the matching public
+key auto-trusted under ~/.dbx/.trust/.
+
+The resulting license carries a "dev" claim that prints a warning
+banner whenever it is loaded — DO NOT use dev-issued licenses in
+production deployments.`,
+		Example: `  dbxcli license issue --tier enterprise \
+    --bundles provision,dataguard,audit \
+    --subject lab-dev --expires 365d \
+    --out ~/.dbx/license.jwt`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			t := license.Tier(strings.ToLower(tier))
+			switch t {
+			case license.TierCommunity, license.TierBusiness, license.TierEnterprise:
+			default:
+				return fmt.Errorf("invalid --tier %q (want community|business|enterprise)", tier)
+			}
+			expSecs, err := parseDuration(expires)
+			if err != nil {
+				return err
+			}
+			now := time.Now().Unix()
+			tok, err := license.IssueDev(license.License{
+				Subject:   subject,
+				Tier:      t,
+				Bundles:   bundles,
+				IssuedAt:  now,
+				ExpiresAt: now + expSecs,
+			})
+			if err != nil {
+				return err
+			}
+			if outPath != "" {
+				out := expandHome(outPath)
+				if out == license.Path() {
+					if err := license.Save(tok); err != nil {
+						return err
+					}
+				} else {
+					if err := os.WriteFile(out, []byte(tok), 0o600); err != nil {
+						return fmt.Errorf("write %s: %w", out, err)
+					}
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "WARNING: dev-issued license written to %s\n", out)
+				fmt.Fprintln(cmd.OutOrStdout(), "         This license is self-signed and NOT valid for production.")
+			} else {
+				fmt.Fprintln(cmd.OutOrStdout(), tok)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&tier, "tier", "enterprise", "tier: community|business|enterprise")
+	cmd.Flags().StringSliceVar(&bundles, "bundles", nil, "comma-separated bundle list (e.g. provision,dataguard)")
+	cmd.Flags().StringVar(&subject, "subject", "lab-dev", "license subject (sub claim)")
+	cmd.Flags().StringVar(&expires, "expires", "365d", "duration until expiry (e.g. 30d, 24h, 365d)")
+	cmd.Flags().StringVar(&outPath, "out", "", "output path (default: stdout). Use ~/.dbx/license.jwt to install.")
+	return cmd
+}
+
+// parseDuration accepts NNh / NNd / standard time.ParseDuration values
+// and returns the equivalent number of seconds.
+func parseDuration(s string) (int64, error) {
+	if s == "" {
+		return 0, errors.New("empty duration")
+	}
+	if strings.HasSuffix(s, "d") {
+		n, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		return int64(n) * 86400, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	return int64(d.Seconds()), nil
+}
+
+// expandHome rewrites a leading ~ to $HOME.
+func expandHome(p string) string {
+	if strings.HasPrefix(p, "~/") || p == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return strings.Replace(p, "~", home, 1)
+		}
+	}
+	return p
+}

--- a/cmd/dbxcli/root/provision_install.go
+++ b/cmd/dbxcli/root/provision_install.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/itunified-io/dbx/pkg/license"
 	"github.com/itunified-io/dbx/pkg/provision/install"
 	"github.com/spf13/cobra"
 )
@@ -27,11 +28,9 @@ func resolveTarget(cmd *cobra.Command, localTarget string) (string, error) {
 // NewInstallCmd returns the `provision install` parent subcommand.
 // Each leaf delegates to a function in dbx/pkg/provision/install/.
 //
-// License gate: provision domain maps to BundleOps
-// (pkg/core/license.DomainToBundle["provision"]). A RequireTier/RequireBundle
-// helper does not yet exist in pkg/core/license — tracked in #519.
-// When that helper ships, add:  license.RequireBundle(license.BundleOps)
-// at the top of each RunE.
+// License gate: every leaf below calls license.RequireBundle("provision")
+// at the top of its RunE. Bundle gates implicitly require Enterprise tier
+// (see pkg/license/require.go). #27 / ADR-0094.
 func NewInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -89,7 +88,10 @@ reverter follow-up plan.`,
     --admin-password-file /tmp/pdbadmin.pw \
     --datafile-dest +DATA`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			// Tier-gate: provision bundle (Enterprise tier) — see pkg/license + ADR-0094.
+			if err := license.RequireBundle("provision"); err != nil {
+				return fmt.Errorf("dbxcli provision: %w", err)
+			}
 			t, err := resolveTarget(cmd, spec.Target)
 			if err != nil {
 				return err
@@ -156,7 +158,10 @@ step is deferred to a reverter follow-up plan.`,
     --response-file /tmp/dbca.rsp \
     --db-unique-name ORCL`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			// Tier-gate: provision bundle (Enterprise tier) — see pkg/license + ADR-0094.
+			if err := license.RequireBundle("provision"); err != nil {
+				return fmt.Errorf("dbxcli provision: %w", err)
+			}
 			t, err := resolveTarget(cmd, spec.Target)
 			if err != nil {
 				return err
@@ -219,7 +224,10 @@ label-removal step is deferred to a reverter follow-up plan.`,
     --impl asmlib \
     --labels DATA1:/dev/sdb,DATA2:/dev/sdc`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			// Tier-gate: provision bundle (Enterprise tier) — see pkg/license + ADR-0094.
+			if err := license.RequireBundle("provision"); err != nil {
+				return fmt.Errorf("dbxcli provision: %w", err)
+			}
 			t, err := resolveTarget(cmd, spec.Target)
 			if err != nil {
 				return err
@@ -296,7 +304,10 @@ deferred to a reverter follow-up plan.`,
     --response-file /tmp/netca.rsp \
     --listener-name LISTENER --port 1521`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			// Tier-gate: provision bundle (Enterprise tier) — see pkg/license + ADR-0094.
+			if err := license.RequireBundle("provision"); err != nil {
+				return fmt.Errorf("dbxcli provision: %w", err)
+			}
 			t, err := resolveTarget(cmd, spec.Target)
 			if err != nil {
 				return err
@@ -354,7 +365,10 @@ deferred to a reverter follow-up plan.`,
     --dg-name DATA --disks /dev/sdb,/dev/sdc \
     --redundancy EXTERNAL --au-size-mb 4`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			// Tier-gate: provision bundle (Enterprise tier) — see pkg/license + ADR-0094.
+			if err := license.RequireBundle("provision"); err != nil {
+				return fmt.Errorf("dbxcli provision: %w", err)
+			}
 			t, err := resolveTarget(cmd, spec.Target)
 			if err != nil {
 				return err
@@ -400,7 +414,10 @@ func newInstallDbhomeCmd() *cobra.Command {
 		Use:   "dbhome",
 		Short: "Run runInstaller -silent for Oracle DB Home 19c",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			// Tier-gate: provision bundle (Enterprise tier) — see pkg/license + ADR-0094.
+			if err := license.RequireBundle("provision"); err != nil {
+				return fmt.Errorf("dbxcli provision: %w", err)
+			}
 			t, err := resolveTarget(cmd, spec.Target)
 			if err != nil {
 				return err
@@ -438,7 +455,10 @@ func newInstallRootshCmd() *cobra.Command {
 		Use:   "root-sh",
 		Short: "Run <OracleHome>/root.sh idempotently after a runInstaller",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO(#519): wire license.RequireBundle("provision") once helper ships
+			// Tier-gate: provision bundle (Enterprise tier) — see pkg/license + ADR-0094.
+			if err := license.RequireBundle("provision"); err != nil {
+				return fmt.Errorf("dbxcli provision: %w", err)
+			}
 			t, err := resolveTarget(cmd, spec.Target)
 			if err != nil {
 				return err
@@ -486,6 +506,10 @@ Idempotency:
     --oracle-base /u01/app/grid \
     --response-file /tmp/grid.rsp`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Tier-gate: provision bundle (Enterprise tier) — see pkg/license + ADR-0094.
+			if err := license.RequireBundle("provision"); err != nil {
+				return fmt.Errorf("dbxcli provision: %w", err)
+			}
 			t, err := resolveTarget(cmd, spec.Target)
 			if err != nil {
 				return err

--- a/cmd/dbxcli/root/provision_install_e2e_test.go
+++ b/cmd/dbxcli/root/provision_install_e2e_test.go
@@ -102,9 +102,14 @@ func TestProvisionInstall_TargetResolution(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	combined := strings.ToLower(err.Error() + " " + out.String())
-	// Either the resolveTarget error, or the SSH attempt error if a
-	// stray default --target slipped in (defensive).
+	// One of:
+	//   - tier gate: provision bundle requires Enterprise tier
+	//     (no license configured in test env — this is the post-#27 norm)
+	//   - resolveTarget error
+	//   - SSH attempt error if a stray default --target slipped in
 	assert.True(t,
-		strings.Contains(combined, "target") || strings.Contains(combined, "ssh"),
-		"expected target-related error, got: %s", combined)
+		strings.Contains(combined, "tier gate") ||
+			strings.Contains(combined, "target") ||
+			strings.Contains(combined, "ssh"),
+		"expected tier-gate / target / ssh error, got: %s", combined)
 }

--- a/cmd/dbxcli/root/root.go
+++ b/cmd/dbxcli/root/root.go
@@ -102,35 +102,8 @@ Supports stdio transport (default) and SSE transport for remote connections.`,
 }
 
 // NewLicenseCmd creates the "license" subcommand group.
+//
+// Real implementation lives in license.go (pkg/license-backed).
 func NewLicenseCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "license",
-		Short: "Manage dbx license",
-		Long: `Manage the dbx license. Licenses are Ed25519-signed JWT tokens stored at ~/.dbx/license.jwt.
-Without a license, only OSS (Community) features are available.`,
-	}
-	cmd.AddCommand(&cobra.Command{
-		Use:     "status",
-		Short:   "Show license status",
-		Long:    `Show current license status including tier, entity count, expiry date, and grace period.`,
-		Example: `  dbxcli license status`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("license: OSS (no license file)")
-			return nil
-		},
-	})
-	activateCmd := &cobra.Command{
-		Use:     "activate",
-		Short:   "Activate a license file",
-		Long:    `Activate a license JWT file. The file is validated, copied to ~/.dbx/license.jwt, and EE features are unlocked.`,
-		Example: `  dbxcli license activate --file /path/to/license.jwt`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			file, _ := cmd.Flags().GetString("file")
-			fmt.Printf("activating license from %s\n", file)
-			return nil
-		},
-	}
-	activateCmd.Flags().String("file", "", "path to license JWT file")
-	cmd.AddCommand(activateCmd)
-	return cmd
+	return newLicenseCmd()
 }

--- a/pkg/license/issuer.go
+++ b/pkg/license/issuer.go
@@ -1,0 +1,89 @@
+package license
+
+// DEV-MODE ONLY
+//
+// This file implements local self-signed license issuance for lab
+// and development use. Production licenses MUST be issued by the
+// dbx license CA (TBD), which holds an offline Ed25519 signing key.
+//
+// On first invocation, IssueDev:
+//   1. Generates an Ed25519 keypair into ~/.dbx/.signing-key.ed25519 (mode 0600).
+//   2. Writes the matching public key to ~/.dbx/.trust/dev-<fingerprint>.pub (mode 0644).
+//   3. Signs a License with the freshly-generated private key.
+//   4. Returns the compact JWS.
+//
+// Subsequent invocations reuse the same private key.
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// IssueDev signs a License with a locally-generated Ed25519 key,
+// auto-trusting it via ~/.dbx/.trust/.
+//
+// The supplied claims have their Dev flag forced to true so the
+// verifier prints a warning when the resulting JWT is later loaded.
+//
+// IssueDev returns the compact JWS string. Callers wishing to
+// persist it to ~/.dbx/license.jwt should pass the result to Save.
+func IssueDev(claims License) (string, error) {
+	if claims.Tier == "" {
+		return "", errors.New("license: IssueDev: tier required")
+	}
+	priv, err := loadOrCreateDevKey()
+	if err != nil {
+		return "", err
+	}
+	claims.Dev = true // DEV-MODE: stamp every dev-issued license
+	return signJWT(&claims, priv)
+}
+
+// loadOrCreateDevKey returns the dev signing private key, creating
+// it (and its trusted public counterpart) on first call.
+func loadOrCreateDevKey() (ed25519.PrivateKey, error) {
+	if err := os.MkdirAll(dbxDir(), 0o700); err != nil {
+		return nil, fmt.Errorf("license: mkdir %s: %w", dbxDir(), err)
+	}
+	if err := os.MkdirAll(trustDir(), 0o700); err != nil {
+		return nil, fmt.Errorf("license: mkdir %s: %w", trustDir(), err)
+	}
+
+	if data, err := os.ReadFile(devKeyPath()); err == nil {
+		if len(data) != ed25519.PrivateKeySize {
+			return nil, fmt.Errorf("license: dev key %s: unexpected size %d", devKeyPath(), len(data))
+		}
+		return ed25519.PrivateKey(append([]byte(nil), data...)), nil
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("license: read dev key: %w", err)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("license: generate dev key: %w", err)
+	}
+	if err := os.WriteFile(devKeyPath(), priv, 0o600); err != nil {
+		return nil, fmt.Errorf("license: write dev key: %w", err)
+	}
+
+	// Public key fingerprint (first 8 bytes of sha256, hex-encoded)
+	// keeps trust filenames short + collision-resistant for human eyes.
+	sum := sha256.Sum256(pub)
+	fp := hex.EncodeToString(sum[:8])
+	pubFile := filepath.Join(trustDir(), "dev-"+fp+".pub")
+	pubB64 := base64.StdEncoding.EncodeToString(pub)
+	contents := "# DEV-MODE Ed25519 dev license verification key\n" +
+		"# Fingerprint: " + fp + "\n" +
+		pubB64 + "\n"
+	if err := os.WriteFile(pubFile, []byte(contents), 0o644); err != nil {
+		return nil, fmt.Errorf("license: write trust pub: %w", err)
+	}
+	return priv, nil
+}

--- a/pkg/license/jwt.go
+++ b/pkg/license/jwt.go
@@ -1,0 +1,100 @@
+package license
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// jwtHeader is the fixed header for dbx licenses. Algorithm is pinned
+// to EdDSA — verifiers MUST reject any other alg to prevent confusion
+// attacks (e.g., none / HS256 with the public key as HMAC secret).
+type jwtHeader struct {
+	Alg string `json:"alg"`
+	Typ string `json:"typ"`
+}
+
+// signJWT produces a compact JWS (header.payload.sig, base64url) for
+// the given license claims using the supplied Ed25519 private key.
+//
+// The output is a single self-contained string suitable for writing
+// to ~/.dbx/license.jwt.
+func signJWT(claims *License, priv ed25519.PrivateKey) (string, error) {
+	if priv == nil {
+		return "", errors.New("license: signJWT: nil private key")
+	}
+	hdrJSON, err := json.Marshal(jwtHeader{Alg: "EdDSA", Typ: "JWT"})
+	if err != nil {
+		return "", fmt.Errorf("license: marshal header: %w", err)
+	}
+	payloadJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("license: marshal claims: %w", err)
+	}
+	hdr := base64.RawURLEncoding.EncodeToString(hdrJSON)
+	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signingInput := hdr + "." + payload
+	sig := ed25519.Sign(priv, []byte(signingInput))
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// verifyJWT parses and verifies a compact JWS produced by signJWT
+// against any of the supplied trusted public keys.
+//
+// On success it returns the decoded License. On failure it returns
+// ErrInvalidFormat, ErrInvalidSignature, or a wrapping error.
+//
+// The function is deliberately strict: it rejects unknown alg values
+// (alg pinning) and requires every key in trusted to be 32 bytes.
+func verifyJWT(token string, trusted []ed25519.PublicKey) (*License, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, ErrInvalidFormat
+	}
+	hdrBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("%w: header b64: %v", ErrInvalidFormat, err)
+	}
+	var hdr jwtHeader
+	if err := json.Unmarshal(hdrBytes, &hdr); err != nil {
+		return nil, fmt.Errorf("%w: header json: %v", ErrInvalidFormat, err)
+	}
+	// Algorithm pinning. Reject anything other than EdDSA outright.
+	if hdr.Alg != "EdDSA" {
+		return nil, fmt.Errorf("%w: unexpected alg %q", ErrInvalidFormat, hdr.Alg)
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("%w: payload b64: %v", ErrInvalidFormat, err)
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("%w: sig b64: %v", ErrInvalidFormat, err)
+	}
+
+	signingInput := []byte(parts[0] + "." + parts[1])
+
+	verified := false
+	for _, pub := range trusted {
+		if len(pub) != ed25519.PublicKeySize {
+			continue
+		}
+		if ed25519.Verify(pub, signingInput, sig) {
+			verified = true
+			break
+		}
+	}
+	if !verified {
+		return nil, ErrInvalidSignature
+	}
+
+	var lic License
+	if err := json.Unmarshal(payloadBytes, &lic); err != nil {
+		return nil, fmt.Errorf("%w: claims json: %v", ErrInvalidFormat, err)
+	}
+	return &lic, nil
+}

--- a/pkg/license/jwt_test.go
+++ b/pkg/license/jwt_test.go
@@ -1,0 +1,83 @@
+package license
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func mustKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+func TestSignVerify_Roundtrip(t *testing.T) {
+	pub, priv := mustKeypair(t)
+	claims := &License{
+		Subject: "lab-dev",
+		Tier:    TierEnterprise,
+		Bundles: []string{"provision", "dataguard"},
+	}
+	tok, err := signJWT(claims, priv)
+	if err != nil {
+		t.Fatalf("signJWT: %v", err)
+	}
+	if strings.Count(tok, ".") != 2 {
+		t.Fatalf("expected compact JWS with 2 dots, got %q", tok)
+	}
+	got, err := verifyJWT(tok, []ed25519.PublicKey{pub})
+	if err != nil {
+		t.Fatalf("verifyJWT: %v", err)
+	}
+	if got.Subject != "lab-dev" || got.Tier != TierEnterprise || len(got.Bundles) != 2 {
+		t.Fatalf("roundtrip mismatch: %+v", got)
+	}
+}
+
+func TestVerify_RejectsUnknownSigner(t *testing.T) {
+	_, priv := mustKeypair(t)
+	otherPub, _ := mustKeypair(t)
+	tok, err := signJWT(&License{Subject: "x", Tier: TierEnterprise}, priv)
+	if err != nil {
+		t.Fatalf("signJWT: %v", err)
+	}
+	_, err = verifyJWT(tok, []ed25519.PublicKey{otherPub})
+	if !errors.Is(err, ErrInvalidSignature) {
+		t.Fatalf("expected ErrInvalidSignature, got %v", err)
+	}
+}
+
+func TestVerify_RejectsWrongAlg(t *testing.T) {
+	pub, _ := mustKeypair(t)
+	// Hand-crafted token with alg "none"
+	tok := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ4In0." // base64url of {"alg":"none","typ":"JWT"}.{"sub":"x"}.empty
+	_, err := verifyJWT(tok, []ed25519.PublicKey{pub})
+	if !errors.Is(err, ErrInvalidFormat) {
+		t.Fatalf("expected ErrInvalidFormat (alg pin), got %v", err)
+	}
+}
+
+func TestVerify_RejectsMalformed(t *testing.T) {
+	pub, _ := mustKeypair(t)
+	for _, bad := range []string{"", "abc", "a.b", "a.b.c.d", "!.@.#"} {
+		if _, err := verifyJWT(bad, []ed25519.PublicKey{pub}); !errors.Is(err, ErrInvalidFormat) {
+			t.Errorf("bad input %q: expected ErrInvalidFormat, got %v", bad, err)
+		}
+	}
+}
+
+func TestVerify_TrustedSubsetMatches(t *testing.T) {
+	pubA, privA := mustKeypair(t)
+	pubB, _ := mustKeypair(t)
+	tok, _ := signJWT(&License{Subject: "x", Tier: TierEnterprise}, privA)
+	// Trust list contains B first then A — must still find A.
+	if _, err := verifyJWT(tok, []ed25519.PublicKey{pubB, pubA}); err != nil {
+		t.Fatalf("expected verify success with subset, got %v", err)
+	}
+}

--- a/pkg/license/keys/README.md
+++ b/pkg/license/keys/README.md
@@ -1,0 +1,33 @@
+# pkg/license/keys/
+
+This directory holds public Ed25519 verification keys for dbx licenses.
+
+## prod.pub
+
+`prod.pub` is the production license verification key.
+
+**Status: PLACEHOLDER**. This file is intentionally empty until the dbx
+license CA is provisioned. While empty:
+
+- Production-issued licenses CANNOT verify (there is no key to verify
+  against).
+- Only DEV-MODE licenses (self-signed locally and trusted via
+  `~/.dbx/.trust/`) verify successfully.
+- All tier-gated commands therefore require a dev-issued license,
+  printed with a `WARNING: dev-issued license` banner.
+
+When the production CA is ready, replace this file with the
+PEM-encoded Ed25519 public key. The verifier reads it via Go's
+`embed.FS` at compile time, so a clean rebuild ships the new key.
+
+## Format
+
+Two formats are supported:
+
+1. **Raw 32-byte** Ed25519 public key (`ed25519.PublicKeySize`).
+2. **Base64-encoded** (standard or raw URL) 32-byte key, with optional
+   `# ...` comment lines stripped before decoding.
+
+The verifier auto-detects format. Empty / whitespace-only files are
+treated as "no production key" and silently skipped (so the binary
+still builds and dev licenses still work).

--- a/pkg/license/require.go
+++ b/pkg/license/require.go
@@ -1,0 +1,57 @@
+package license
+
+import "errors"
+
+// RequireBundle returns nil if the local license is present, valid
+// (not expired), enterprise-tier, and includes the named bundle.
+//
+// Otherwise it returns an *ErrTierGate whose Cause indicates the
+// underlying reason (ErrMissing, ErrExpired, etc).
+//
+// Bundle gates implicitly require Enterprise tier — Community and
+// Business tiers never satisfy a bundle gate.
+//
+// Callers SHOULD wrap the returned error to add command context, e.g.:
+//
+//	if err := license.RequireBundle("provision"); err != nil {
+//	    return fmt.Errorf("dbxcli provision install grid: %w", err)
+//	}
+func RequireBundle(bundle string) error {
+	lic, err := Load()
+	if err != nil {
+		return &ErrTierGate{Bundle: bundle, Tier: TierEnterprise, Cause: err}
+	}
+	if vErr := lic.IsValid(); vErr != nil {
+		return &ErrTierGate{Bundle: bundle, Tier: TierEnterprise, Cause: vErr}
+	}
+	if !lic.HasTier(TierEnterprise) {
+		return &ErrTierGate{Bundle: bundle, Tier: TierEnterprise, Cause: errors.New("license tier is " + string(lic.Tier))}
+	}
+	if !lic.HasBundle(bundle) {
+		return &ErrTierGate{Bundle: bundle, Tier: TierEnterprise, Cause: errors.New("license does not include bundle " + bundle)}
+	}
+	return nil
+}
+
+// RequireTier returns nil if the local license meets the requested
+// minimum tier and is not expired.
+//
+// TierCommunity is satisfied by ANY valid license AND by ErrMissing
+// (no license file = community user). Higher tiers require an
+// explicit license.
+func RequireTier(min Tier) error {
+	lic, err := Load()
+	if err != nil {
+		if errors.Is(err, ErrMissing) && min == TierCommunity {
+			return nil
+		}
+		return &ErrTierGate{Tier: min, Cause: err}
+	}
+	if vErr := lic.IsValid(); vErr != nil {
+		return &ErrTierGate{Tier: min, Cause: vErr}
+	}
+	if !lic.HasTier(min) {
+		return &ErrTierGate{Tier: min, Cause: errors.New("license tier is " + string(lic.Tier))}
+	}
+	return nil
+}

--- a/pkg/license/store.go
+++ b/pkg/license/store.go
@@ -1,0 +1,157 @@
+package license
+
+import (
+	"crypto/ed25519"
+	_ "embed"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed keys/prod.pub
+var embeddedProdKey []byte
+
+// pathOverride lets tests redirect Path() to a temp directory.
+// Production callers MUST NOT touch this — they use Path() directly.
+var pathOverride string
+
+// Path returns the on-disk path of the dbx license file.
+//
+// Default: $HOME/.dbx/license.jwt. The directory is NOT created here;
+// callers that intend to write (Save, IssueDev) are responsible for
+// MkdirAll on the parent.
+func Path() string {
+	if pathOverride != "" {
+		return filepath.Join(pathOverride, "license.jwt")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// Best-effort fallback: cwd. Caller errors will surface clearly.
+		return ".dbx/license.jwt"
+	}
+	return filepath.Join(home, ".dbx", "license.jwt")
+}
+
+// dbxDir returns the on-disk dbx config dir (parent of license.jwt).
+func dbxDir() string {
+	return filepath.Dir(Path())
+}
+
+// trustDir returns the directory of trusted dev public keys.
+func trustDir() string {
+	return filepath.Join(dbxDir(), ".trust")
+}
+
+// devKeyPath returns the path of the local dev signing private key.
+func devKeyPath() string {
+	return filepath.Join(dbxDir(), ".signing-key.ed25519")
+}
+
+// trustedKeys assembles the verifier trust list:
+//   - the embedded production key (if non-empty)
+//   - every *.pub file under ~/.dbx/.trust/ (dev keys)
+func trustedKeys() []ed25519.PublicKey {
+	var keys []ed25519.PublicKey
+	if pk, ok := decodePubKey(embeddedProdKey); ok {
+		keys = append(keys, pk)
+	}
+	matches, _ := filepath.Glob(filepath.Join(trustDir(), "*.pub"))
+	for _, m := range matches {
+		data, err := os.ReadFile(m)
+		if err != nil {
+			continue
+		}
+		if pk, ok := decodePubKey(data); ok {
+			keys = append(keys, pk)
+		}
+	}
+	return keys
+}
+
+// decodePubKey parses an Ed25519 public key from a file payload.
+// It accepts:
+//   - raw 32-byte binary
+//   - base64 (std or raw URL), with #-comment lines stripped
+//
+// Empty / whitespace-only input returns ok=false.
+func decodePubKey(data []byte) (ed25519.PublicKey, bool) {
+	if len(data) == ed25519.PublicKeySize {
+		return ed25519.PublicKey(append([]byte(nil), data...)), true
+	}
+	// Strip comments + whitespace.
+	var sb strings.Builder
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		sb.WriteString(line)
+	}
+	s := sb.String()
+	if s == "" {
+		return nil, false
+	}
+	for _, dec := range []func(string) ([]byte, error){
+		base64.StdEncoding.DecodeString,
+		base64.RawStdEncoding.DecodeString,
+		base64.URLEncoding.DecodeString,
+		base64.RawURLEncoding.DecodeString,
+	} {
+		if raw, err := dec(s); err == nil && len(raw) == ed25519.PublicKeySize {
+			return ed25519.PublicKey(raw), true
+		}
+	}
+	return nil, false
+}
+
+// Load reads, parses, and verifies the dbx license at Path().
+//
+// Returns:
+//   - (nil, ErrMissing)    — no file present; caller should treat as TierCommunity.
+//   - (nil, ErrInvalidFormat | ErrInvalidSignature) — file present but unusable.
+//   - (license, nil)       — license verified by a trusted key. Expiry NOT enforced
+//     here; call lic.IsValid() / RequireBundle / RequireTier for that.
+//
+// Dev-issued licenses cause a one-line warning to be written to stderr.
+func Load() (*License, error) {
+	data, err := os.ReadFile(Path())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrMissing
+		}
+		return nil, fmt.Errorf("license: read %s: %w", Path(), err)
+	}
+	tok := strings.TrimSpace(string(data))
+	if tok == "" {
+		return nil, ErrMissing
+	}
+	keys := trustedKeys()
+	if len(keys) == 0 {
+		// No prod key embedded and no dev keys trusted. Any license
+		// in this state must be treated as untrusted.
+		return nil, fmt.Errorf("%w: no trusted verification keys (no prod.pub, no dev trust)", ErrInvalidSignature)
+	}
+	lic, err := verifyJWT(tok, keys)
+	if err != nil {
+		return nil, err
+	}
+	if lic.Dev {
+		fmt.Fprintln(os.Stderr, "WARNING: dev-issued license loaded from "+Path()+" — not for production use")
+	}
+	return lic, nil
+}
+
+// Save writes the JWT string to Path() with mode 0600. The parent
+// directory is created (mode 0700) if it does not exist.
+func Save(jwt string) error {
+	if err := os.MkdirAll(dbxDir(), 0o700); err != nil {
+		return fmt.Errorf("license: mkdir %s: %w", dbxDir(), err)
+	}
+	if err := os.WriteFile(Path(), []byte(jwt), 0o600); err != nil {
+		return fmt.Errorf("license: write %s: %w", Path(), err)
+	}
+	return nil
+}

--- a/pkg/license/store_test.go
+++ b/pkg/license/store_test.go
@@ -1,0 +1,231 @@
+package license
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// withTempHome redirects Path() to a temp dir for the duration of the test.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	prev := pathOverride
+	pathOverride = filepath.Join(dir, ".dbx")
+	if err := os.MkdirAll(pathOverride, 0o700); err != nil {
+		t.Fatalf("mkdir override: %v", err)
+	}
+	t.Cleanup(func() { pathOverride = prev })
+	return dir
+}
+
+func TestPath_Override(t *testing.T) {
+	withTempHome(t)
+	p := Path()
+	if filepath.Base(p) != "license.jwt" {
+		t.Fatalf("Path() = %s, want suffix license.jwt", p)
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	withTempHome(t)
+	_, err := Load()
+	if !errors.Is(err, ErrMissing) {
+		t.Fatalf("expected ErrMissing, got %v", err)
+	}
+}
+
+func TestSaveLoad_DevRoundtrip(t *testing.T) {
+	withTempHome(t)
+	tok, err := IssueDev(License{
+		Subject:   "lab-dev",
+		Tier:      TierEnterprise,
+		Bundles:   []string{"provision"},
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(24 * time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("IssueDev: %v", err)
+	}
+	if err := Save(tok); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	lic, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !lic.Dev {
+		t.Error("expected Dev=true on dev-issued license")
+	}
+	if !lic.HasBundle("provision") {
+		t.Error("expected HasBundle(provision)")
+	}
+	if !lic.HasTier(TierEnterprise) {
+		t.Error("expected Enterprise tier")
+	}
+	// File mode check
+	info, err := os.Stat(Path())
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("license file mode = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestIssueDev_KeyIsIdempotent(t *testing.T) {
+	withTempHome(t)
+	if _, err := IssueDev(License{Tier: TierEnterprise}); err != nil {
+		t.Fatalf("first IssueDev: %v", err)
+	}
+	keyPath := devKeyPath()
+	info1, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("stat dev key: %v", err)
+	}
+	if _, err := IssueDev(License{Tier: TierEnterprise}); err != nil {
+		t.Fatalf("second IssueDev: %v", err)
+	}
+	info2, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("stat dev key 2: %v", err)
+	}
+	if info1.ModTime() != info2.ModTime() {
+		t.Errorf("dev key was rewritten: %v -> %v", info1.ModTime(), info2.ModTime())
+	}
+}
+
+func TestLoad_RejectsTamperedToken(t *testing.T) {
+	withTempHome(t)
+	tok, err := IssueDev(License{Tier: TierEnterprise, Bundles: []string{"provision"}})
+	if err != nil {
+		t.Fatalf("IssueDev: %v", err)
+	}
+	// Mutate one byte in the payload (middle segment).
+	bad := []byte(tok)
+	// Find dot positions
+	first, second := -1, -1
+	for i, b := range bad {
+		if b == '.' {
+			if first == -1 {
+				first = i
+			} else {
+				second = i
+				break
+			}
+		}
+	}
+	bad[first+1] ^= 0x01
+	if err := Save(string(bad)); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_, err = Load()
+	if err == nil {
+		t.Fatal("expected verify failure on tampered token")
+	}
+	_ = second
+}
+
+func TestRequireBundle_MissingLicense(t *testing.T) {
+	withTempHome(t)
+	err := RequireBundle("provision")
+	if err == nil {
+		t.Fatal("expected ErrTierGate, got nil")
+	}
+	gate, ok := err.(*ErrTierGate)
+	if !ok {
+		t.Fatalf("expected *ErrTierGate, got %T: %v", err, err)
+	}
+	if gate.Bundle != "provision" {
+		t.Errorf("Bundle = %q, want provision", gate.Bundle)
+	}
+	if !errors.Is(err, ErrMissing) {
+		t.Errorf("expected wrap of ErrMissing, got Cause=%v", gate.Cause)
+	}
+}
+
+func TestRequireBundle_DevLicenseWithBundle(t *testing.T) {
+	withTempHome(t)
+	tok, _ := IssueDev(License{
+		Tier:      TierEnterprise,
+		Bundles:   []string{"provision"},
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	})
+	if err := Save(tok); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := RequireBundle("provision"); err != nil {
+		t.Fatalf("RequireBundle = %v, want nil", err)
+	}
+}
+
+func TestRequireBundle_DevLicenseWithoutBundle(t *testing.T) {
+	withTempHome(t)
+	tok, _ := IssueDev(License{
+		Tier:      TierEnterprise,
+		Bundles:   []string{"audit"},
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	})
+	_ = Save(tok)
+	err := RequireBundle("provision")
+	if err == nil {
+		t.Fatal("expected ErrTierGate, got nil")
+	}
+	if _, ok := err.(*ErrTierGate); !ok {
+		t.Fatalf("expected *ErrTierGate, got %T", err)
+	}
+}
+
+func TestRequireBundle_Expired(t *testing.T) {
+	withTempHome(t)
+	tok, _ := IssueDev(License{
+		Tier:      TierEnterprise,
+		Bundles:   []string{"provision"},
+		ExpiresAt: time.Now().Add(-time.Hour).Unix(),
+	})
+	_ = Save(tok)
+	err := RequireBundle("provision")
+	if !errors.Is(err, ErrExpired) {
+		t.Fatalf("expected ErrExpired, got %v", err)
+	}
+}
+
+func TestRequireBundle_BusinessTierRejected(t *testing.T) {
+	withTempHome(t)
+	tok, _ := IssueDev(License{
+		Tier:      TierBusiness,
+		Bundles:   []string{"provision"},
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	})
+	_ = Save(tok)
+	if err := RequireBundle("provision"); err == nil {
+		t.Fatal("expected gate failure on business tier")
+	}
+}
+
+func TestRequireTier_CommunityWithNoLicense(t *testing.T) {
+	withTempHome(t)
+	if err := RequireTier(TierCommunity); err != nil {
+		t.Errorf("Community gate must accept no-license: got %v", err)
+	}
+	if err := RequireTier(TierEnterprise); err == nil {
+		t.Error("Enterprise gate must reject no-license")
+	}
+}
+
+func TestDecodePubKey_Variants(t *testing.T) {
+	// Empty
+	if _, ok := decodePubKey(nil); ok {
+		t.Error("empty input must return ok=false")
+	}
+	// Comment-only
+	if _, ok := decodePubKey([]byte("# comment\n#another\n")); ok {
+		t.Error("comment-only must return ok=false")
+	}
+	// Random non-32-byte raw
+	if _, ok := decodePubKey([]byte{1, 2, 3}); ok {
+		t.Error("3-byte input must return ok=false")
+	}
+}

--- a/pkg/license/types.go
+++ b/pkg/license/types.go
@@ -1,0 +1,172 @@
+// Package license provides a tier-gated license facade for the dbxcli.
+//
+// This package implements ADR-0094 (per-tool JWT licensing) for the dbx
+// monolith CLI: an Ed25519-signed JWT stored at ~/.dbx/license.jwt,
+// loaded once per command, and consulted via RequireBundle/RequireTier
+// at the top of gated leaf RunE functions.
+//
+// Licensing model:
+//   - Tiers: community < business < enterprise (ordered).
+//   - Bundles: capability tags within a license, e.g. "provision",
+//     "dataguard", "audit". Enterprise tier with the matching bundle
+//     unlocks gated commands.
+//   - Production licenses verify against an embedded Ed25519 public key
+//     at pkg/license/keys/prod.pub (placeholder until the dbx license
+//     CA is provisioned).
+//   - DEV-MODE licenses are self-signed by the local issuer and
+//     verify against locally-trusted keys under ~/.dbx/.trust/.
+//
+// This package is intentionally independent of pkg/core/license: that
+// package implements the broader JWT validation infrastructure used
+// by the pipeline runtime (kid-based key sets, CRL, grace, entity
+// counts). pkg/license is the slim tier-gate the dbxcli leaf
+// commands call into. The two are aligned semantically (same Ed25519
+// + JWT primitives) but kept decoupled to avoid cyclic dependencies
+// and to keep this gate trivially auditable.
+package license
+
+import (
+	"errors"
+	"time"
+)
+
+// Tier is the license tier level. Tiers are ordered:
+//
+//	community < business < enterprise
+//
+// HasTier checks whether a license meets a minimum requested tier.
+type Tier string
+
+const (
+	// TierCommunity is the default tier for users with no license file.
+	// OSS / read-only / non-gated tools work at this tier.
+	TierCommunity Tier = "community"
+
+	// TierBusiness unlocks the standard paid feature set.
+	TierBusiness Tier = "business"
+
+	// TierEnterprise unlocks every paid feature including ops/provision,
+	// data guard, audit, and other Enterprise-only bundles.
+	TierEnterprise Tier = "enterprise"
+)
+
+// tierRank returns the ordering rank of a tier. Higher = more privileged.
+// Unknown tiers map to -1 (less privileged than community).
+func tierRank(t Tier) int {
+	switch t {
+	case TierCommunity:
+		return 0
+	case TierBusiness:
+		return 1
+	case TierEnterprise:
+		return 2
+	default:
+		return -1
+	}
+}
+
+// License is the decoded JWT payload of a dbx license.
+//
+// Field tags match the JWT claim names defined in ADR-0094.
+type License struct {
+	Subject   string   `json:"sub"`
+	Tier      Tier     `json:"tier"`
+	Bundles   []string `json:"bundles"`
+	IssuedAt  int64    `json:"iat"`
+	ExpiresAt int64    `json:"exp"`
+
+	// Dev marks a license as dev-issued (self-signed). When true,
+	// the verifier emits a warning on Load() and downstream gates
+	// MAY treat the license as untrusted in production builds.
+	Dev bool `json:"dev,omitempty"`
+}
+
+// IsValid returns nil if the license is currently valid (not expired)
+// and an error otherwise.
+//
+// Expiry is checked against the wall clock. Licenses with ExpiresAt
+// of zero are treated as non-expiring (used by long-lived dev keys).
+func (l *License) IsValid() error {
+	if l == nil {
+		return ErrMissing
+	}
+	if l.ExpiresAt == 0 {
+		return nil
+	}
+	if time.Now().Unix() >= l.ExpiresAt {
+		return ErrExpired
+	}
+	return nil
+}
+
+// HasBundle reports whether the license includes the named bundle.
+func (l *License) HasBundle(name string) bool {
+	if l == nil {
+		return false
+	}
+	for _, b := range l.Bundles {
+		if b == name {
+			return true
+		}
+	}
+	return false
+}
+
+// HasTier reports whether the license meets or exceeds the requested
+// minimum tier. Unknown tiers always fail.
+func (l *License) HasTier(min Tier) bool {
+	if l == nil {
+		return false
+	}
+	have := tierRank(l.Tier)
+	want := tierRank(min)
+	if have < 0 || want < 0 {
+		return false
+	}
+	return have >= want
+}
+
+// Sentinel errors. Callers SHOULD use errors.Is to test for these.
+var (
+	// ErrMissing indicates no license file is present at the default path.
+	// Callers MAY treat this as TierCommunity.
+	ErrMissing = errors.New("license: no license file")
+
+	// ErrExpired indicates the license file is well-formed and
+	// signed by a trusted key, but past its exp claim.
+	ErrExpired = errors.New("license: expired")
+
+	// ErrInvalidSignature indicates the JWT signature did not verify
+	// against any trusted key.
+	ErrInvalidSignature = errors.New("license: invalid signature")
+
+	// ErrInvalidFormat indicates the file at the license path is
+	// not a parseable EdDSA-signed JWT.
+	ErrInvalidFormat = errors.New("license: invalid format")
+)
+
+// ErrTierGate is returned by RequireTier/RequireBundle when a license
+// gate is not satisfied. It implements Unwrap so callers can match
+// the sentinel via errors.Is.
+type ErrTierGate struct {
+	Bundle string
+	Tier   Tier
+	Cause  error
+}
+
+// Error renders a human-readable gate message.
+func (e *ErrTierGate) Error() string {
+	switch {
+	case e.Bundle != "" && e.Tier != "":
+		return "tier gate: " + e.Bundle + " bundle requires " + string(e.Tier) + " tier"
+	case e.Bundle != "":
+		return "tier gate: " + e.Bundle + " bundle requires Enterprise tier"
+	case e.Tier != "":
+		return "tier gate: requires " + string(e.Tier) + " tier"
+	default:
+		return "tier gate: license required"
+	}
+}
+
+// Unwrap surfaces the underlying cause (e.g. ErrMissing, ErrExpired).
+func (e *ErrTierGate) Unwrap() error { return e.Cause }

--- a/pkg/license/types_test.go
+++ b/pkg/license/types_test.go
@@ -1,0 +1,92 @@
+package license
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestLicense_IsValid(t *testing.T) {
+	cases := []struct {
+		name string
+		lic  *License
+		want error
+	}{
+		{"nil license", nil, ErrMissing},
+		{"no expiry", &License{Tier: TierEnterprise}, nil},
+		{"future expiry", &License{ExpiresAt: time.Now().Add(time.Hour).Unix()}, nil},
+		{"past expiry", &License{ExpiresAt: time.Now().Add(-time.Hour).Unix()}, ErrExpired},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.lic.IsValid()
+			if !errors.Is(got, tc.want) && got != tc.want {
+				t.Fatalf("IsValid() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLicense_HasBundle(t *testing.T) {
+	l := &License{Bundles: []string{"provision", "dataguard"}}
+	if !l.HasBundle("provision") {
+		t.Error("expected HasBundle(provision) = true")
+	}
+	if l.HasBundle("audit") {
+		t.Error("expected HasBundle(audit) = false")
+	}
+	var nilLic *License
+	if nilLic.HasBundle("provision") {
+		t.Error("nil license must not have any bundle")
+	}
+}
+
+func TestLicense_HasTier_Ordering(t *testing.T) {
+	cases := []struct {
+		have, min Tier
+		want      bool
+	}{
+		{TierCommunity, TierCommunity, true},
+		{TierCommunity, TierBusiness, false},
+		{TierCommunity, TierEnterprise, false},
+		{TierBusiness, TierCommunity, true},
+		{TierBusiness, TierBusiness, true},
+		{TierBusiness, TierEnterprise, false},
+		{TierEnterprise, TierCommunity, true},
+		{TierEnterprise, TierBusiness, true},
+		{TierEnterprise, TierEnterprise, true},
+		{Tier("garbage"), TierCommunity, false},
+		{TierEnterprise, Tier("garbage"), false},
+	}
+	for _, tc := range cases {
+		l := &License{Tier: tc.have}
+		got := l.HasTier(tc.min)
+		if got != tc.want {
+			t.Errorf("(have=%s,min=%s) HasTier=%v, want %v", tc.have, tc.min, got, tc.want)
+		}
+	}
+}
+
+func TestErrTierGate_Error(t *testing.T) {
+	cases := []struct {
+		e    *ErrTierGate
+		want string
+	}{
+		{&ErrTierGate{Bundle: "provision", Tier: TierEnterprise}, "tier gate: provision bundle requires enterprise tier"},
+		{&ErrTierGate{Bundle: "provision"}, "tier gate: provision bundle requires Enterprise tier"},
+		{&ErrTierGate{Tier: TierBusiness}, "tier gate: requires business tier"},
+		{&ErrTierGate{}, "tier gate: license required"},
+	}
+	for _, tc := range cases {
+		if got := tc.e.Error(); got != tc.want {
+			t.Errorf("Error() = %q, want %q", got, tc.want)
+		}
+	}
+}
+
+func TestErrTierGate_Unwrap(t *testing.T) {
+	gate := &ErrTierGate{Bundle: "provision", Cause: ErrMissing}
+	if !errors.Is(gate, ErrMissing) {
+		t.Error("expected errors.Is(gate, ErrMissing) = true")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #27.

- New `pkg/license/` — slim Ed25519 JWT facade (`Tier`, `License`, `RequireBundle`, `RequireTier`) with embedded `keys/prod.pub` placeholder and `~/.dbx/.trust/` dev key trust list.
- `dbxcli license status / activate / issue` (DEV-MODE) backed by the new package.
- `license.RequireBundle("provision")` wired into all 8 `provision install` leaf RunEs (grid, dbhome, root-sh, asmca, netca, asm-label, dbca, pdb), replacing the `// TODO(#519)` markers.
- 22 new unit tests; full suite green.

Per ADR-0094 (per-tool JWT licensing). Production verification key remains a placeholder until the dbx license CA is provisioned — only DEV-MODE self-signed licenses verify today.

## Test plan
- [x] `go test ./pkg/license/... -race` green
- [x] `go test ./cmd/dbxcli/... -race` green
- [x] `go test ./... -race` — 79 packages green
- [x] `go build ./...` clean
- [x] CLI verification (no license / dev-issue / status / install grid / rm / install grid) — see commit message body

## Verification output

```
$ bin/dbxcli license status
license: OSS (no license file)
         Community-tier features only.

$ bin/dbxcli license issue --tier enterprise --bundles provision,dataguard --subject lab-dev --out ~/.dbx/license.jwt
WARNING: dev-issued license written to .../license.jwt

$ bin/dbxcli license status
WARNING: dev-issued license loaded ... — not for production use
tier     : enterprise
bundles  : provision, dataguard
state    : valid

$ bin/dbxcli provision install grid --target test --oracle-home /tmp/foo --response-file /tmp/missing.rsp
Error: runInstaller exit 255 on test; check log_tail in result   # license OK, gate passed

$ rm ~/.dbx/license.jwt && rm -rf ~/.dbx/.trust ~/.dbx/.signing-key.ed25519

$ bin/dbxcli provision install grid --target test --oracle-home /tmp/foo --response-file /tmp/missing.rsp
Error: dbxcli provision: tier gate: provision bundle requires enterprise tier
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)