### PR TITLE
fix(provision/install): grid entrypoint + sshExecutor target.yaml + detection (#35)

### DIFF
--- a/pkg/oracle/sql/sshexec.go
+++ b/pkg/oracle/sql/sshexec.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/itunified-io/dbx/pkg/core/target"
 	"github.com/itunified-io/dbx/pkg/host"
 )
 
@@ -14,23 +15,47 @@ import (
 // so the install package's executor can evolve independently (e.g.
 // inventory-based credentials, sudo-flag toggling) without coupling.
 type sshExecutor struct {
-	target string
+	target  string
+	host    string
+	user    string
+	keyPath string
 }
 
 // newSSHExecutor returns an Executor that runs commands on the named
-// dbx target via the local ssh binary. The target must resolve via the
-// SSH config of the invoking shell (~/.ssh/config or environment); per-
-// target credential resolution is the caller's responsibility (planned
-// follow-up: integrate with pkg/core/target SSH endpoint resolution).
-func newSSHExecutor(_ context.Context, target string) (host.Executor, error) {
-	if strings.TrimSpace(target) == "" {
+// dbx target via the local ssh binary. Resolves connection details from
+// the dbx target registry (~/.dbx/targets/<name>.yaml). Falls back to
+// the bare target name for SSH config-driven setups.
+func newSSHExecutor(_ context.Context, name string) (host.Executor, error) {
+	if strings.TrimSpace(name) == "" {
 		return nil, fmt.Errorf("target must not be empty")
 	}
-	return &sshExecutor{target: target}, nil
+	e := &sshExecutor{target: name}
+	if t, err := target.Load(name); err == nil && t.SSH != nil {
+		e.host = t.SSH.Host
+		e.user = t.SSH.User
+		e.keyPath = t.SSH.KeyPath
+	}
+	return e, nil
 }
 
 func (e *sshExecutor) Run(ctx context.Context, command string) (*host.RunResult, error) {
-	cmd := exec.CommandContext(ctx, "ssh", e.target, command) //nolint:gosec
+	args := []string{
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "BatchMode=yes",
+	}
+	if e.keyPath != "" {
+		args = append(args, "-i", e.keyPath)
+	}
+	dest := e.target
+	if e.host != "" {
+		if e.user != "" {
+			dest = e.user + "@" + e.host
+		} else {
+			dest = e.host
+		}
+	}
+	args = append(args, dest, command)
+	cmd := exec.CommandContext(ctx, "ssh", args...) //nolint:gosec
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/pkg/provision/install/grid.go
+++ b/pkg/provision/install/grid.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/itunified-io/dbx/pkg/core/target"
 	"github.com/itunified-io/dbx/pkg/host"
 	"github.com/itunified-io/dbx/pkg/otel"
 )
@@ -65,7 +66,11 @@ func gridInstallWithExec(ctx context.Context, exec host.Executor, spec InstallSp
 		return nil, fmt.Errorf("ResponseFilePath required when state=absent (caller must render + scp the .rsp first)")
 	}
 
-	cmd := fmt.Sprintf("%s/runInstaller -silent -responseFile %s -ignorePrereqFailure",
+	// Oracle 19c Grid Infrastructure silent install entry-point is gridSetup.sh
+	// (NOT runInstaller — that is for DB Home only). The -waitforcompletion
+	// flag prevents runInstaller from forking + returning control before the
+	// install actually completes (otherwise our exit code is meaningless).
+	cmd := fmt.Sprintf("%s/gridSetup.sh -silent -responseFile %s -ignorePrereqFailure -waitforcompletion",
 		shellEscape(spec.OracleHome), shellEscape(spec.ResponseFilePath))
 	runRes, err := exec.Run(ctx, cmd)
 	if err != nil {
@@ -83,45 +88,84 @@ func gridInstallWithExec(ctx context.Context, exec host.Executor, spec InstallSp
 	return res, nil
 }
 
-// detectGridState probes for prior Grid install evidence per the
-// Oracle 19c canonical detection rule:
-//   /etc/oraInst.loc present  + $GRID_HOME/inventory non-empty → installed
-//   one but not the other                                       → partial
-//   neither                                                     → absent
+// detectGridState probes for prior Grid install evidence.
+//
+// The canonical signal for Oracle 19c is /etc/oraInst.loc: it is
+// created exclusively by orainstRoot.sh (run as root after the GUI
+// or silent install completes) and points at the central inventory
+// (oraInventory/ContentsXML/inventory.xml) where the registered
+// ORACLE_HOMEs are listed.
+//
+// We DO NOT probe $GRID_HOME/inventory because that directory ships
+// pre-populated inside the Grid Home zip (Components21/, Actions21/,
+// ContentsXML/, etc.) regardless of whether the install ever ran —
+// using it as a signal produces false-positive "partial" states on
+// every freshly extracted Grid Home, which then forces operators to
+// invoke an unimplemented --reset path. (Caught live on ext3adm1 +
+// ext4adm1, infra ext3+ext4 lab, 2026-05-03.)
+//
+// Future enhancement: parse inventory.xml from oraInst.loc and verify
+// the gridHome path is registered, distinguishing partial from full.
 func detectGridState(ctx context.Context, exec host.Executor, gridHome string) (DetectionState, error) {
+	_ = gridHome // reserved for future inventory.xml cross-check
 	hasOraInst, err := probeFile(ctx, exec, "/etc/oraInst.loc")
 	if err != nil {
 		return DetectionStateAbsent, err
 	}
-	hasInventory, err := probeDirNonEmpty(ctx, exec, gridHome+"/inventory")
-	if err != nil {
-		return DetectionStateAbsent, err
-	}
-	switch {
-	case hasOraInst && hasInventory:
+	if hasOraInst {
 		return DetectionStateInstalled, nil
-	case !hasOraInst && !hasInventory:
-		return DetectionStateAbsent, nil
-	default:
-		return DetectionStatePartial, nil
 	}
+	return DetectionStateAbsent, nil
 }
 
 // sshExecutor implements host.Executor using the local ssh binary.
-// Used by GridInstall (the non-test path).
+// Used by GridInstall (the non-test path) and the other install primitives
+// in this package.
+//
+// Resolves connection details from the dbx target registry
+// (~/.dbx/targets/<name>.yaml) — host, user, key_path. Falls back to
+// the bare target name for SSH config-driven setups.
 type sshExecutor struct {
-	target string
+	target  string
+	host    string
+	user    string
+	keyPath string
 }
 
-func newSSHExecutor(_ context.Context, target string) (host.Executor, error) {
-	if strings.TrimSpace(target) == "" {
+func newSSHExecutor(_ context.Context, name string) (host.Executor, error) {
+	if strings.TrimSpace(name) == "" {
 		return nil, fmt.Errorf("target must not be empty")
 	}
-	return &sshExecutor{target: target}, nil
+	e := &sshExecutor{target: name}
+	// Best-effort load from ~/.dbx/targets/<name>.yaml. If the load fails
+	// (target not registered yet, malformed YAML, etc.) fall back to ssh
+	// config defaults so existing flows keep working.
+	if t, err := target.Load(name); err == nil && t.SSH != nil {
+		e.host = t.SSH.Host
+		e.user = t.SSH.User
+		e.keyPath = t.SSH.KeyPath
+	}
+	return e, nil
 }
 
 func (e *sshExecutor) Run(ctx context.Context, command string) (*host.RunResult, error) {
-	cmd := exec.CommandContext(ctx, "ssh", e.target, command) //nolint:gosec
+	args := []string{
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "BatchMode=yes",
+	}
+	if e.keyPath != "" {
+		args = append(args, "-i", e.keyPath)
+	}
+	dest := e.target
+	if e.host != "" {
+		if e.user != "" {
+			dest = e.user + "@" + e.host
+		} else {
+			dest = e.host
+		}
+	}
+	args = append(args, dest, command)
+	cmd := exec.CommandContext(ctx, "ssh", args...) //nolint:gosec
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/pkg/provision/install/grid.go
+++ b/pkg/provision/install/grid.go
@@ -70,8 +70,20 @@ func gridInstallWithExec(ctx context.Context, exec host.Executor, spec InstallSp
 	// (NOT runInstaller — that is for DB Home only). The -waitforcompletion
 	// flag prevents runInstaller from forking + returning control before the
 	// install actually completes (otherwise our exit code is meaningless).
-	cmd := fmt.Sprintf("%s/gridSetup.sh -silent -responseFile %s -ignorePrereqFailure -waitforcompletion",
-		shellEscape(spec.OracleHome), shellEscape(spec.ResponseFilePath))
+	//
+	// Two contextual wrappers are required:
+	//   - The Grid Home is mode 0750 grid:oinstall, so gridSetup.sh MUST run
+	//     as the `grid` OS user. dbx ssh logs in as root (per target.yaml),
+	//     so we shell out via `sudo -u grid bash -c '...'`.
+	//   - Oracle 19.3.0 base does not list OL9.x in its supported-OS table,
+	//     causing INS-08101 supportedOSCheck NPE. Standard remediation is
+	//     to set CV_ASSUME_DISTID to a known-good value (OEL8 covers OL9
+	//     prereq parity for cluvfy + the OS check).
+	cmd := fmt.Sprintf(
+		"sudo -u grid -H bash -c %s",
+		shellQuote(fmt.Sprintf(
+			"export CV_ASSUME_DISTID=OEL8 && cd /tmp && %s/gridSetup.sh -silent -responseFile %s -ignorePrereqFailure -waitforcompletion",
+			shellEscape(spec.OracleHome), shellEscape(spec.ResponseFilePath))))
 	runRes, err := exec.Run(ctx, cmd)
 	if err != nil {
 		if ctx.Err() != nil {

--- a/pkg/provision/install/grid_test.go
+++ b/pkg/provision/install/grid_test.go
@@ -38,7 +38,7 @@ func TestGridInstall(t *testing.T) {
 				m.OnCommand("test -f /etc/oraInst.loc").Returns(1, "", "")
 				m.OnCommand("test -d /u01/app/19c/grid/inventory && ls -A /u01/app/19c/grid/inventory | head -1").
 					Returns(1, "", "")
-				m.OnCommandPattern(`/u01/app/19c/grid/runInstaller -silent -responseFile /tmp/grid\.rsp.*`).
+				m.OnCommandPattern(`/u01/app/19c/grid/gridSetup\.sh -silent -responseFile /tmp/grid\.rsp.*`).
 					Returns(0, "Installation Successful.\n", "")
 			},
 			spec: InstallSpec{
@@ -55,17 +55,12 @@ func TestGridInstall(t *testing.T) {
 			spec:      InstallSpec{},
 			wantErr:   "target is required",
 		},
-		{
-			name: "PartialState_AbortsWithoutReset",
-			setupMock: func(m *hosttest.MockExecutor) {
-				m.OnCommand("test -f /etc/oraInst.loc").
-					Returns(0, "inventory_loc=/u01/app/oraInventory\n", "")
-				m.OnCommand("test -d /u01/app/19c/grid/inventory && ls -A /u01/app/19c/grid/inventory | head -1").
-					Returns(1, "", "")
-			},
-			spec:    InstallSpec{Target: "ext3adm1", OracleHome: "/u01/app/19c/grid"},
-			wantErr: "partial install detected",
-		},
+		// Note: "PartialState" detection used to fire when /etc/oraInst.loc
+		// was present but $GRID_HOME/inventory was empty. Removed in the
+		// 2026-05-03 detector simplification: $GRID_HOME/inventory ships
+		// pre-populated in the Grid Home zip and is not a reliable signal.
+		// Detection is now oraInst.loc-only. Future enhancement: parse
+		// inventory.xml from oraInst.loc to distinguish partial from full.
 	}
 
 	for _, tc := range cases {

--- a/pkg/provision/install/helpers.go
+++ b/pkg/provision/install/helpers.go
@@ -83,3 +83,11 @@ func shellEscape(s string) string {
 	}
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
+
+// shellQuote unconditionally wraps a string in single quotes and escapes
+// embedded single quotes. Used for the inner command of `bash -c '...'`
+// where we always want the surrounding quotes regardless of content
+// (vs shellEscape which omits quotes for safe-character-only strings).
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}


### PR DESCRIPTION
Closes #35.

Three compounding bugs caught live on the ext3+ext4 lab during /lab-up Phase D.2 (2026-05-03):

## Bug 1 — wrong gridSetup entry-point
`runInstaller` is the DB Home entry-point. Oracle 19c GI must use `gridSetup.sh`. Live symptom: `-bash: /u01/app/19.0.0/grid/runInstaller: No such file or directory` → exit 127 wrapped as 255.

## Bug 2 — sshExecutor ignored target.yaml
Both copies (pkg/provision/install + pkg/oracle/sql) called `ssh <target>` blindly, relying on `~/.ssh/config`. dbx-registered targets carry `ssh.host/user/key_path` in `~/.dbx/targets/<name>.yaml`; we now load them and emit `-i <key> <user>@<host>`.

## Bug 3 — `$GRID_HOME/inventory` not a useful signal
Pre-populated by the Grid Home zip; treating it as partial-install evidence misclassifies every freshly extracted home and forces an unimplemented `--reset` runbook. Detection is now `/etc/oraInst.loc`-only.

## Test plan
- [x] `go test ./pkg/provision/install/... ./pkg/oracle/sql/...` green
- [x] Verified `gridSetup.sh` invocation against live ext3adm1 (process now starts; new failure mode is the run-as-grid + supportedOSCheck gap, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)